### PR TITLE
Bumps grunt-bower-task which fixes a grunt vendor error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "latest",
     "grunt-autoprefixer": "~0.6.5",
     "grunt-banner": "latest",
-    "grunt-bower-task": "~0.3.2",
+    "grunt-bower-task": "~0.4.0",
     "grunt-browserify": "2.0.3",
     "grunt-combine-media-queries": "~1.0.2",
     "grunt-contrib-clean": "latest",


### PR DESCRIPTION
We need to bump grunt-bower-task because it is using an older version of bower which recently had an issue: https://github.com/bower/bower/pull/1403

Without this `grunt vendor` breaks.
