### PR TITLE
highlight current nav item in loan options

### DIFF
--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set active_page = "loan-types" %}
+{% set active_page = "loan-options" %}
 
 {% block title %}Owning a Home: Loan Options{% endblock title %}
 
@@ -41,7 +41,7 @@
       </section>
 
     </section> <!-- /.content_main -->
-    
+
     <aside class="content_sidebar sans">
       <header class="tabbed-header">
         <h3 class="subhead tabbed-heading">Related Links</h3>

--- a/src/loan-options/conventional-loans/index.html
+++ b/src/loan-options/conventional-loans/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set active_page = "loan-types" %}
+{% set active_page = "loan-options" %}
 
 {% block title %}Owning a Home: Loan options{% endblock title %}
 

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -8,7 +8,7 @@
 <main class="content content__1-3" id="main" role="main">
   <div class="wrap content_wrapper">
     <aside class="content_sidebar">
-      {% with active_page = "loan-types" %}
+      {% with active_page = "loan-options" %}
         {% include "sidebar_nav.html" %}
       {% endwith %}
     </aside>

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set active_page = "loan-types" %}
+{% set active_page = "loan-options" %}
 
 {% block title %}Owning a Home: Loan options{% endblock title %}
 


### PR DESCRIPTION
This was missed in the renaming to `loan-options`
