### PR TITLE
scroll back to the top of the container when using a collapse link

### DIFF
--- a/src/static/js/modules/mega-expand.js
+++ b/src/static/js/modules/mega-expand.js
@@ -15,15 +15,17 @@ var megaExpand = function(ev, $header){
 
 };
 
-
+// expand/collapse link bheavior in expandable-header
 $('.expandable').on( 'click', '.expandable-mainhead', function(ev){
   var $header = $(this).parent('.expandable-header');
   megaExpand(ev, $header);
 });
 
+// collapse link
 $('.expandable').on( 'click', '.expand-close', function(ev){
   var $header = $(this).parents('.expandable').find('.expandable-header');
   megaExpand(ev, $header);
+  // scroll back to the top of the container
   var offSet = $header.offset().top;
   $('body').scrollTop(offSet);
 });


### PR DESCRIPTION
This works well in modern browsers, but IE still has the old behavior.
![selfie-0](http://i.imgur.com/kCswPyq.gif)
