### PR TITLE
Fixed Owning a Home beta link on loan options subpage

### DIFF
--- a/src/_layouts/loan_types_subpage_heading.html
+++ b/src/_layouts/loan_types_subpage_heading.html
@@ -5,6 +5,6 @@
   </div>
 
   <div class="col-6 oah-title-right">
-    <h1 class="oah-title"><a href="/owning-a-home/loan-options">Owning a Home <sup class="beta">BETA</sup></a></h1>
+    <h1 class="oah-title"><a href="/owning-a-home/">Owning a Home <sup class="beta">BETA</sup></a></h1>
   </div>
 </div> <!-- /.wrapper -->


### PR DESCRIPTION
It previously pointed to the loan options page, now it directs you to the owning-a-home landing page. Yippee!

![selfie-1](http://i.imgur.com/ASRpOMw.gif)
