### PR TITLE
added/removed tags so that only @smoke_tests will run as part of the build-flow

### DIFF
--- a/test/browser_testing/features/home.feature
+++ b/test/browser_testing/features/home.feature
@@ -6,7 +6,7 @@ So that I can find the information I'm looking for
 Background:
    Given I navigate to the OAH Landing page
 
-@smoke_testing @landing_page
+@smoke_testing @landing_page @email_signup
 Scenario Outline: Testing valid email signup
   When I enter "<email_address>"
     And I click the Signup button
@@ -18,7 +18,7 @@ Examples:
   | test123@gmail.com     |
   | mr.tester@github.com  |
 
-@smoke_testing @landing_page
+@landing_page @email_signup
 Scenario Outline: Testing multiple messages
   When I enter "<email_address>"
     And I click the Signup button

--- a/test/browser_testing/features/loan_comparison.feature
+++ b/test/browser_testing/features/loan_comparison.feature
@@ -6,7 +6,7 @@ Feature: Test the default values in the Loan Comparison page
 Background:
    Given I navigate to the "Loan Comparison" page
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: Test inbound links in the Loan Options page
    When I click on the "Check out the Rate Checker" link
    Then I should be directed to the internal "rate-checker" URL

--- a/test/browser_testing/features/loan_comparison_defaults.feature
+++ b/test/browser_testing/features/loan_comparison_defaults.feature
@@ -6,189 +6,189 @@ Feature: Test the default values in the Loan Comparison page
 Background:
    Given I navigate to the "Loan Comparison" page
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see Loan A but NOT Loan B or C
   Then I should see the "Loan A" column
     But I should NOT see the "Loan B" column
     But I should NOT see the "Loan C" column
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default State selected for Loan A
   Then I should see "Alabama" as default State for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default State selected for Loan B
   When I click Add another loan
   Then I should see "Alabama" as default State for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default State selected for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "Alabama" as default State for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Credit Score for Loan A
   Then I should see "701 - 720" as default Credit Score for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Credit Score for Loan B
   When I click Add another loan
   Then I should see "701 - 720" as default Credit Score for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Credit Score for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "701 - 720" as default Credit Score for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Amount for Loan A
   Then I should see "$180,000" as default Loan Amount for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Amount for Loan B
   When I click Add another loan
     And I click Add another loan again
   Then I should see "$180,000" as default Loan Amount for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Amount for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "$180,000" as default Loan Amount for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default House Price for Loan A
   Then I should see "$200,000" as default House Price for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default House Price for Loan B
   When I click Add another loan
     And I click Add another loan again
   Then I should see "$200,000" as default House Price for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default House Price for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "$200,000" as default House Price for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment percent for Loan A
   Then I should see "10" as default Down Payment percent for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment percent for Loan B
   When I click Add another loan
   Then I should see "10" as default Down Payment percent for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment percent for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "10" as default Down Payment percent for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment amount for Loan A
   Then I should see "$20,000" as default Down Payment amount for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment amount for Loan B
   When I click Add another loan
   Then I should see "$20,000" as default Down Payment amount for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Down Payment amount for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "$20,000" as default Down Payment amount for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Rate Structure for Loan A
   Then I should see "Fixed" as default Rate Structure for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Rate Structure for Loan B
   When I click Add another loan
   Then I should see "Fixed" as default Rate Structure for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Rate Structure for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "Fixed" as default Rate Structure for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Term for Loan A
   Then I should see "30 years" as default Loan Term for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Term for Loan B
   When I click Add another loan
   Then I should see "30 years" as default Loan Term for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Term for Loan B
   When I click Add another loan
     And I click Add another loan again
   Then I should see "30 years" as default Loan Term for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Type for Loan A
   Then I should see "Conventional" as default Loan Type for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Type for Loan B
   When I click Add another loan
   Then I should see "Conventional" as default Loan Type for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default Loan Type for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "Conventional" as default Loan Type for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default ARM Type for Loan A
   Then I should see "3/1" as default ARM Type for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default ARM Type for Loan B
   When I click Add another loan
   Then I should see "3/1" as default ARM Type for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time visitor should see default ARM Type for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "3/1" as default ARM Type for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Discount point and credits for Loan A
   Then I should see "0" as default Discount point and credits for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Discount point and credits for Loan B
   When I click Add another loan
   Then I should see "0" as default Discount point and credits for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Discount point and credits for Loan C
   When I click Add another loan
     And I click Add another loan again
   Then I should see "0" as default Discount point and credits for "Loan C"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Interest Rate for Loan A
   Then I should see "3.25%" as default Interest Rate for "Loan A"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Interest Rate for Loan B
   When I click Add another loan
   Then I should see "3.25%" as default Interest Rate for "Loan B"
 
-@smoke_testing @loan_comparison
+@loan_comparison
 Scenario: First time Desktop visitor should see default Interest Rate for Loan C
   When I click Add another loan
     And I click Add another loan again

--- a/test/browser_testing/features/loan_conventional.feature
+++ b/test/browser_testing/features/loan_conventional.feature
@@ -19,7 +19,7 @@ Examples:
   | FHA loans 					       | /loan-options/FHA-loans/ 								              | Loan Options  |
   | More on mortgage insurance | /loan-options/conventional-loans/#mortgage-insurance	  | Loan Options  |
 
-@smoke_testing @loan_options @prod_only
+@loan_options @prod_only
 Scenario Outline: Test outbound links in the Conventional Loan page
 	When I click on the "<link_name>" link
 	Then I should be directed to the external "<full_url>" URL
@@ -43,10 +43,6 @@ Scenario Outline: Test Related links in the Conventional Loan page
 		And I should see "<page_title>" displayed in the page title
 
 Examples:
-  | loan_type   	  				| relative_url								| page_title 	|
-  | Related Link FHA 				| /loan-options/FHA-loans/ 					| Loan Options  |
-  | Related Link Special Programs 	| /loan-options/special-loan-programs/ 		| Loan Options  |
-
-
-
-
+  | loan_type   	  				        | relative_url							             | page_title    |
+  | Related Link FHA 				        | /loan-options/FHA-loans/ 					     | Loan Options  |
+  | Related Link Special Programs	  | /loan-options/special-loan-programs/ 	 | Loan Options  |

--- a/test/browser_testing/features/loan_fha.feature
+++ b/test/browser_testing/features/loan_fha.feature
@@ -21,18 +21,18 @@ Examples:
 
 
 
-@smoke_testing @loan_options @prod_only
+@loan_options @prod_only
 Scenario Outline: Test outbound links in the FHA Loan page
 	When I click on the "<link_name>" link
 	Then I should be directed to the external "<full_url>" URL
 		And I should see "<page_title>" displayed in the page title
 
 Examples:
-  | link_name       	  											  | full_url		 																  | page_title 							  |
-  | Federal Housing Administration									  | http://portal.hud.gov/hudportal/HUD?src=/federal_housing_administration  		  | Federal Housing Administration 		  |
-  | Learn your FHA loan limit 										  | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html 	  | Consumer Financial Protection Bureau  |
-  | Learn more about mortgage insurance 							  | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html 				  | Consumer Financial Protection Bureau  |
-  | How can I find the loan limit for an FHA loan in my county?       | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html     | Consumer Financial Protection Bureau  |
+  | link_name       	  											                  | full_url		 																                                  | page_title 							              |
+  | Federal Housing Administration									            | http://portal.hud.gov/hudportal/HUD?src=/federal_housing_administration  		  | Federal Housing Administration 		    |
+  | Learn your FHA loan limit 										              | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
+  | Learn more about mortgage insurance 							          | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html 				    | Consumer Financial Protection Bureau  |
+  | How can I find the loan limit for an FHA loan in my county? | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
 
 
 @smoke_testing @loan_options
@@ -42,7 +42,7 @@ Scenario Outline: Test Related links in the FHA Loan page
 		And I should see "<page_title>" displayed in the page title
 
 Examples:
-  | loan_type   	  				| relative_url								| page_title 	|
-  | Related Link Conventional 		| /loan-options/conventional-loans/ 		| Loan Options  |
+  | loan_type   	  				        | relative_url								              | page_title 	|
+  | Related Link Conventional 		  | /loan-options/conventional-loans/ 		    | Loan Options  |
   | Related Link Special Programs   | /loan-options/special-loan-programs/      | Loan Options  |
 

--- a/test/browser_testing/features/loan_options.feature
+++ b/test/browser_testing/features/loan_options.feature
@@ -18,8 +18,8 @@ Examples:
   | Interest rate type      | Compare your interest rate options  |
   | Loan type 				      | Choosing the right loan type 		    |
 
-@smoke_testing @loan_options
-Scenario Outline: Click 'Collapse' to collapse sections
+@loan_options
+Scenario Outline: Click 'Collapse' button to collapse sections
 	When I click Learn More to expand the "<section_name>" section
 		And I collapse the "<section_name>" section
 	Then I should NOT see the "<section_name>" section expanded
@@ -30,8 +30,8 @@ Examples:
   | Interest rate type       |
   | Loan type 				       |
 
-@smoke_testing @loan_options
-Scenario Outline: Click 'Collapse <section_name>' to collapse sections
+@loan_options
+Scenario Outline: Click 'Collapse <section_name>' link to collapse sections
   When I click Learn More to expand the "<section_name>" section
     And I click on the "<link_name>" link
   Then I should NOT see the "<section_name>" section expanded
@@ -60,7 +60,7 @@ Scenario: Test OAH link in the Loan Options page
    Then I should be directed to the OAH Landing page
 
 
-@smoke_testing @loan_options
+@loan_options
 Scenario Outline: Expand 'Loan Types' section then click links inside the expanded section
   When I click Learn More to expand the "Loan type" section
     And I click Get all the details for "<loan_type>" loans
@@ -73,7 +73,7 @@ Examples:
   | FHA              | loan-options/FHA-loans/             |
   | Special programs | loan-options/special-loan-programs/ |
 
-@smoke_testing @loan_options
+@loan_options
 Scenario Outline: Expand 'Loan Types' section then click links inside the expanded section
   When I click Learn More to expand the "Loan type" section
     And I click on the "<link_name>" link
@@ -83,7 +83,7 @@ Examples:
   | link_name          | full_url                                      |
   | Qualified Mortgage | /askcfpb/1789/what-qualified-mortgage.html    |
 
-@smoke_testing @loan_options
+@loan_options
 Scenario Outline: Expand 'Loan Term' section then click links inside the expanded section
   When I click Learn More to expand the "Loan term" section
     And I click on the "<link_name>" link
@@ -97,7 +97,7 @@ Examples:
   | Good Faith Estimates           | /askcfpb/146/what-is-a-good-faith-estimate-what-is-a-gfe.html                                                                |
   | Learn more about balloon loans | /askcfpb/104/what-is-a-balloon-loan.html                                                                                     |
 
-@smoke_testing @loan_options
+@loan_options
 Scenario Outline: Expand 'Loan Term' section then click links inside the expanded section
   When I click Learn More to expand the "Interest rate type" section
     And I click on the "<link_name>" link

--- a/test/browser_testing/features/loan_options_defaults.feature
+++ b/test/browser_testing/features/loan_options_defaults.feature
@@ -6,7 +6,7 @@ Feature: verify the Loan Options page defaults to the correct values
 Background:
    Given I navigate to the "Loan Options" page
 
-@smoke_testing @loan_options
+@loan_options
 Scenario: Click 'Learn More' to expand sections
    When I click Learn More to expand the "Loan term" section
    Then I should see "$200,000" as the default loan amount

--- a/test/browser_testing/features/loan_special.feature
+++ b/test/browser_testing/features/loan_special.feature
@@ -14,14 +14,14 @@ Scenario Outline: Test inbound links in the Special Programs Loan page
 
 Examples:
   | link_name       	  		     | relative_url											                      | page_title 	  |
-  | Owning a Home              | /                                                      | Owning a Home |
+  | Owning a Home                | /                                                      | Owning a Home |
   | conventional               	 | loan-options/conventional-loans/                       | Loan Options  |
   | FHA                          | loan-options/FHA-loans/                                | Loan Options  |
   | conventional loans           | loan-options/conventional-loans/                       | Loan Options  |
   | More on mortgage insurance   | loan-options/special-loan-programs/#mortgage-insurance | Loan Options  |
   | mortgage insurance           | loan-options/special-loan-programs/#mortgage-insurance | Loan Options  |
 
-@smoke_testing @loan_options @prod_only
+@loan_options @prod_only
 Scenario Outline: Test outbound links in the Special Programs Loan page
 	When I click on the "<link_name>" link
 	Then I should be directed to the external "<full_url>" URL
@@ -37,7 +37,7 @@ Examples:
   | Find out if you're eligible.                | http://eligibility.sc.egov.usda.gov/eligibility/welcomeAction.do    | Welcome                             |
   | this tool                                   | http://downpaymentresource.com/                                     | Down Payment Resource               |
   | local housing counselor                     | /find-a-housing-counselor/                                          | Find a housing counselor            |
-  | Learn more about mortgage insurance         | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html          | What is mortgage insurance and how does it work? |
+  | Learn more about mortgage insurance         | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html  | What is mortgage insurance and how does it work? |
 
 
 @smoke_testing @loan_options

--- a/test/browser_testing/features/rate_checker.feature
+++ b/test/browser_testing/features/rate_checker.feature
@@ -30,7 +30,7 @@ Examples:
   | email_address        |
   | test.abc@yahoo.com   |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Test selecting different states
   When I select "<state_name>" from the Location dropdown list
   Then I should see the selected "<state_name>" above the Rate Checker chart
@@ -41,7 +41,7 @@ Examples:
   | California			|
   | Virginia		    |
 
-@rc @ignore
+@rate_checker @ignore
 Scenario: Test all dropdown lists in the Rate Checker page
   When I select "Adjustable" Rate Structure
     And I select "7/1" ARM Type

--- a/test/browser_testing/features/rate_checker_credit_score.feature
+++ b/test/browser_testing/features/rate_checker_credit_score.feature
@@ -6,33 +6,33 @@ Feature: Test the "Credit score range" slider
 Background:
   Given I navigate to the "Rate Checker" page
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Decrease credit score range
   When I move the credit score slider to the "left"
   Then I should see the credit score range "decrease"
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Increase credit score range
   When I move the credit score slider to the "right"
   Then I should see the credit score range "increase"
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Lowest credit score range
   When I move the credit score slider to the "lowest" range
   Then I should see the Credit Score Range displayed as "600 - 620"
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Highest credit score range
   When I move the credit score slider to the "highest" range
   Then I should see the Credit Score Range displayed as "840 - 860"
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Lowest credit score range alerts
   When I move the credit score slider to the "lowest" range
   Then I should see the credit score slider handle turns "red"
     And I should see an alert for borowers with less than 620 score
 
-@smoke_testing @credit_score
+@credit_score @rate_checker
 Scenario: Lowest credit score range alerts go away when score range increases
   When I move the credit score slider to the "lowest" range
   	And I move the credit score slider to the "right"

--- a/test/browser_testing/features/rate_checker_defaults.feature
+++ b/test/browser_testing/features/rate_checker_defaults.feature
@@ -6,42 +6,42 @@ Feature: Test the Rate Checker fields default to the correct values
 Background:
   Given I navigate to the "Rate Checker" page
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default credit score range
   Then I should see the Credit Score Range displayed as "700 - 720"
  
-@smoke_testing @rc
+@rate_checker
 Scenario: Default location
   Then I should see "District of Columbia" as the selected location 
 
-@smoke_testing @rc  
+@rate_checker  
 Scenario: Default Rate Structure
   Then I should see "Fixed" as the selected Rate Structure
 
-@smoke_testing @rc  
+@rate_checker  
 Scenario: Default Loan Term
   Then I should see "30 Years" as the selected Loan Term
 
-@smoke_testing @rc  
+@rate_checker  
 Scenario: Default Loan Type
   Then I should see "Conventional" as the selected Loan Type
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default House price
   Then I should see $"200,000" as the House price
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default Down Payment amount
   Then I should see $"20,000" as Down Payment amount
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default Down Payment percent
   Then I should see "10" as Down Payment percent
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default loan amount
   Then I should see "$180,000" as Loan Amount
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Default tab
   Then I should see the "I plan to buy in the next couple of months" tab selected

--- a/test/browser_testing/features/rate_checker_links.feature
+++ b/test/browser_testing/features/rate_checker_links.feature
@@ -6,7 +6,7 @@ Feature: test the Rate Checker inbound and outbound links
 Background:
   Given I navigate to the "Rate Checker" page
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Click outbound links
   When I click on the "<link_name>" link in the Rate Checker page
   Then I should see "<page_title>" displayed in the page title
@@ -22,7 +22,7 @@ Examples:
   | credit report                           | Annual Credit Report.com                    	 |
   | get them corrected                      | How do I dispute an error on my credit report? |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Click outbound links inside tab page
   When I click on the "I won’t buy for several months" tab in the Rate Checker page
     And I click on the "<link_name>" link in the Rate Checker page
@@ -34,7 +34,7 @@ Examples:
   | Learn about improving your credit score | How do I get and keep a good credit score?  |
   | Learn more about down payments          | What kind of down payment do I need?        |
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Click internal links
   When I click on the "About our data source" link in the Rate Checker page
   Then I should see the page scroll to the "#about" section

--- a/test/browser_testing/features/rate_checker_loan_amount.feature
+++ b/test/browser_testing/features/rate_checker_loan_amount.feature
@@ -6,7 +6,7 @@ Feature: Test the Loan Amount calculations
 Background:
   Given I navigate to the "Rate Checker" page
 
-@smoke_testing @rc  
+@rate_checker  
 Scenario Outline: Calculate loan amount based on house price and down payment amount
   When I enter $"<house_price>" as House Price amount 
     And I enter $"<down_payment_amount>" as Down Payment amount
@@ -20,7 +20,7 @@ Examples:
   | 1,250,000	  | 187,500 	         | $1,062,500  |
 
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Calculate down payment amount based on house price and down payment percent
   When I enter $"<house_price>" as House Price amount 
     And I enter "<down_payment_percent>" as Down Payment percent
@@ -33,7 +33,7 @@ Examples:
   | 780,000       | 9                      | 70200               |
   | 1,250,000     | 15                     | 187500              |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Calculate down payment percent based on house price and down payment amount
   When I enter $"<house_price>" as House Price amount 
     And I enter $"<down_payment_amount>" as Down Payment amount
@@ -46,7 +46,7 @@ Examples:
   | 780,000       | 70200               | 9                      |
   | 1,250,000     | 237500              | 19                     |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Enter then modify down payment percent
   When I enter $"<house_price>" as House Price amount
     And I enter "<initial_percent>" as Down Payment percent
@@ -58,7 +58,7 @@ Examples:
   | 100,000       | 10                | 20                | 20000               |
   | 250,000       | 30                | 15                | 37500               |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Modify down payment amount
   When I enter $"<house_price>" as House Price amount
     And I enter "<initial_percent>" as Down Payment percent
@@ -70,7 +70,7 @@ Examples:
   | 100,000       | 10                | 9000               | 9                 |
   | 250,000       | 15                | 40000              | 16                |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Modify Down Payment amount then modify the House Price
   When I enter $"<house_price>" as House Price amount
     And I enter "<initial_percent>" as Down Payment percent
@@ -83,7 +83,7 @@ Examples:
   | 100,000       | 10                | 9000               | 175000               | 5                 |
   | 250,000       | 12                | 45000              | 275000               | 16                |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Modify Down Payment percent then modify the House Price
   When I enter $"<house_price>" as House Price amount
     And I enter "<initial_percent>" as Down Payment percent
@@ -96,7 +96,7 @@ Examples:
   | 100000        | 10                | 35000              | 175000               | 20                |
   | 250000        | 12                | 36000              | 225000               | 16                |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Attempt to enter invalid characters as House Price
   When I enter $"<invalid_characters>" as House Price amount
   Then I should see $"<hp_amount>" as the House price

--- a/test/browser_testing/features/rate_checker_loan_details.feature
+++ b/test/browser_testing/features/rate_checker_loan_details.feature
@@ -6,12 +6,12 @@ Feature: verify the Rate Checker tool works according to requirements
 Background:
   Given I navigate to the "Rate Checker" page
 
-@smoke_testing @rc
+@rate_checker
 Scenario: Select the ARM Type
   When I select "Adjustable" Rate Structure
   Then I should see "3/1" as the selected ARM Type
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Select Fixed Rate loans for different loan types and terms
   When I select "<rate_structure>" Rate Structure
   	And I select "<loan_type>" Loan Type
@@ -28,7 +28,7 @@ Examples:
   | Fixed 			     | VA 		      | 30 	      |
   | Fixed 			     | VA 		      | 15 	      |
  
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Select Fixed Rate loans for different loan types and terms
   When I select "<rate_structure>" Rate Structure
   	And I select "<loan_type>" Loan Type
@@ -40,7 +40,7 @@ Examples:
   | rate_structure    | loan_type    | loan_term    | fixed_years |
   | Adjustable 		    | Conventional | 30           | 3 	        |
 
-@smoke_testing @rc
+@rate_checker
 Scenario Outline: Select Adjustable rate and verify that ONLY 30 Year loan term can be selected
   When I select "Adjustable" Rate Structure
   Then Loan type option "<loan_type>" should be "<option_state>"
@@ -50,7 +50,7 @@ Examples:
    | Conventional | enabled      |
    | FHA 		      | disabled     |
 
-@smoke_testing @rc1
+@rate_checker1
 Scenario Outline: Select Adjustable rate and verify that ONLY Conventional loan type can be selected
   When I select "Adjustable" Rate Structure
   Then Loan term option "<loan_term>" should be "<option_state>"


### PR DESCRIPTION
I tagged these browser tests so they can be grouped and executed in Jenkins in the following manner:
- smoke_testing: will run as part of the build flow on code merge
- landing_page, loan_options: run as part of the nightly regression tests
- rate_checker, loan_comparison: will run when we deploy to build or can be run against demo while these modules are being developed
