### PR TITLE
Fix for megaExpand

### DIFF
--- a/src/static/js/modules/mega-expand.js
+++ b/src/static/js/modules/mega-expand.js
@@ -2,10 +2,9 @@ var $ = require('jquery');
 require('./local-storage-polyfill');
 
 var megaExpand = function(ev, $header, duration){
-  if ( duration == undefined ) {
+  if ( duration === undefined ) {
     duration = 400;
   }
-  console.log(duration);
 
   var $container = $header.parent('.expandable'),
       $button = $header.children('.expandable-button'),


### PR DESCRIPTION
![selfie-0](http://i.imgur.com/iJ6hNTF.gif)

`duration` has to be checked to be "truthy" (although I guess `=== undefined` would be fine here too) against `undefined`, not `false`... because `0` should be a valid value for `duration`, but `0` is unfortunately equivalent to `false`.
