### PR TITLE
Fixes for rate-checker.js

### DIFF
--- a/src/static/js/modules/rate-checker.js
+++ b/src/static/js/modules/rate-checker.js
@@ -359,7 +359,6 @@ function loadCounties() {
 
   // And request 'em.
   request = getCounties();
-  console.log(request);
   request.done(function( resp ) {
 
     // If they haven't yet selected a state highlight the field.


### PR DESCRIPTION
![selfie-0](http://i.imgur.com/E5QTFmc.gif)

Here's a few fixes I implemented:
- I found an uncaught error when state wasn't selected. I added an `else` statement to prevent this. I still need to do more work on the county/state data to fix a more different bug. :poodle: 
- I noticed that the page was occasionally sending incorrect numbers to the API. It turns out, sometimes the page didn't seem to operate on the most current values of the fields, instead using old values it had stored. I refactored the event handling at the bottom of the page as a trial balloon, and the page is now doing the proper math with the proper values before querying the API. :fireworks: :fire: :fire_engine: 

This might fix some of the problems we're seeing in calculations... more testing will be required! But these fixes address things I could see were wrong without running any scenarios.
