### PR TITLE
Fix IE8 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
     "hbsfy": "1.3.2",
     "is-money-usd": "0.1.2",
     "jquery": "1.11.0",
-    "jumbo-mortgage": "0.3.0",
+    "jumbo-mortgage": "0.3.1",
     "loan-calc": "0.2.1",
     "median": "0.0.2",
-    "objectified": "0.4.5",   
+    "objectified": "0.4.5",
     "overall-loan-cost": "0.3.4",
     "stay-positive": "0.3.0",
     "unformat-usd": "0.1.1"


### PR DESCRIPTION
The error was located in our jumbo mortgage module. I fixed that in [another pull request](https://github.com/cfpb/jumbo-mortgage/pull/2) and this bumps the version number of that module to update it. :boom: :rocket: 
