### PR TITLE
corrected link at the top of the rate checker

### DIFF
--- a/src/check-rates/index.html
+++ b/src/check-rates/index.html
@@ -13,7 +13,7 @@
       <section class="page-intro">
 
         <div class="col-12 oah-title-tag">
-          <a href="/owning-a-home/loan-options" class="go-back-link l-back-link">Owning a Home</a>
+          <a href="/owning-a-home/" class="go-back-link l-back-link">Owning a Home</a>
         </div>
 
         <div class="col-8">


### PR DESCRIPTION
to point to owning a home landing page
