### PR TITLE
disabled the Tree Viewer during execution

### DIFF
--- a/test/load_testing/OaH.jmx
+++ b/test/load_testing/OaH.jmx
@@ -65,7 +65,7 @@
           <value class="SampleSaveConfiguration">
             <time>true</time>
             <latency>true</latency>
-            <timestamp>true</timestamp>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -91,7 +91,7 @@
         <stringProp name="filename">results/Oah_Aggregate.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>


### PR DESCRIPTION
- Disabled the Results Tree Viewer since it consumes significant resources and it is not needed during execution
- Removed individual timestamp logging for each request since the timestamps is already logged in the Jmeter log file
