### PR TITLE
minor changes to optimize the test

### DIFF
--- a/test/load_testing/OaH.jmx
+++ b/test/load_testing/OaH.jmx
@@ -265,7 +265,7 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/owning-a-home/rate-checker/</stringProp>
+          <stringProp name="HTTPSampler.path">/owning-a-home/check-rates/</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>


### PR DESCRIPTION
- Summary report is disabled during execution
- Thread creation is delayed in order to more efficiently use RAM 
- The corresponding fix is already made in Jenkins/Jmeter.bat to increase max heap memory allocation from 512m to 2048m. 

These changes should enable Jmeter to create enough users to stress the demo server. Otherwise, plan B is to use a distributed Jmeter environment to generate additional users(threads)
