### PR TITLE
fix date parsing for IE8

### DIFF
--- a/src/static/js/modules/format-timestamp.js
+++ b/src/static/js/modules/format-timestamp.js
@@ -1,5 +1,7 @@
 module.exports = function( then ) {
 
+  // format the date for older versions of IE
+  then = then.slice(0, 10).replace('-', '/');
   then = new Date( then );
   return (then.getUTCMonth() + 1) + '/' + then.getUTCDate() + '/' +  then.getUTCFullYear();
 


### PR DESCRIPTION
Because IE8's inability to parse dates with dashes makes a lot of sense. :stuck_out_tongue_closed_eyes: 
