### PR TITLE
added flag to delay thread creation to prevent out of memory errors

### DIFF
--- a/test/load_testing/RateChecker.jmx
+++ b/test/load_testing/RateChecker.jmx
@@ -135,6 +135,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <Summariser guiclass="SummariserGui" testclass="Summariser" testname="API Summary Results" enabled="true"/>


### PR DESCRIPTION
- this flag will tell Jenkins not to create all users at once, rather wait until they're needed, in order to prevent out of memory errors
