### PR TITLE
Debounce removed

### DIFF
--- a/src/static/js/modules/check-rates.js
+++ b/src/static/js/modules/check-rates.js
@@ -1,6 +1,5 @@
 var $ = require('jquery');
 var highcharts = require('highcharts');
-var debounce = require('debounce');
 var formatUSD = require('format-usd');
 var unFormatUSD = require('unformat-usd');
 var interest = require('./total-interest-calc');


### PR DESCRIPTION
I decided to stop trying to force debounce to do something it wasn't meant to do. With the use of a delay after keyup to wait for more keyups before execution, there is no real need to "debounce" and limit the firing of that function - the delay should provide the same protection.

I added a "delay" object (anonymous function, in fact) that accomplishes the needed delay in a tidy way.

Sorry, debounce. I love you, but we're just not right for each other.

![it's not you it's me](http://mrwgifs.com/wp-content/uploads/2013/06/Alison-Brie-Its-Not-You-its-Me-On-Community.gif)
