### PR TITLE
tagged scenarios that only run in production

### DIFF
--- a/test/browser_testing/features/loan_fha.feature
+++ b/test/browser_testing/features/loan_fha.feature
@@ -29,10 +29,17 @@ Examples:
   | link_name                                                   | relative_url                                                                  | page_title                            |
   | conventional loans                                          | /loan-options/conventional-loans/                                             | Loan Options                          |
   | Federal Housing Administration									            | portal.hud.gov/hudportal/HUD?src=/federal_housing_administration  		        | Federal Housing Administration 		    |
-  | Learn your FHA loan limit 										              | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
-  | Learn more about mortgage insurance 							          | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html 				    | Consumer Financial Protection Bureau  |
-  | How can I find the loan limit for an FHA loan in my county? | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
 
+@loan_options @prod_only
+Scenario Outline: Test NON-Navigational links in the FHA Loan page open in a new tab
+  When I click on the "<link_name>" link
+  Then I should see the "<relative_url>" URL with page title <page_title> open in a new tab
+
+Examples:
+  | link_name                                                   | relative_url                                                                  | page_title                            |
+  | Learn your FHA loan limit                                   | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
+  | Learn more about mortgage insurance                         | /askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html            | Consumer Financial Protection Bureau  |
+  | How can I find the loan limit for an FHA loan in my county? | /askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html | Consumer Financial Protection Bureau  |
 
 @smoke_testing @loan_options
 Scenario Outline: Test OTHER LOAN TYPES links in the FHA Loan page

--- a/test/browser_testing/features/rate_checker.feature
+++ b/test/browser_testing/features/rate_checker.feature
@@ -6,7 +6,7 @@ Feature: verify the Rate Checker tool works according to requirements
 Background:
   Given I navigate to the "Rate Checker" page
 
-@beta_signup
+@email_signup
 Scenario Outline: Testing valid email signup
   When I enter "<email_address>"
     And I click the Signup button


### PR DESCRIPTION
Links to ask CFPB and email signup are only available in the production environment so they're tagged as "prod_only" and "email_signup" respectively. That way they won't get executed and fail every time on demo or build.