### PR TITLE
Rate checker links have been removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   "keywords": [],
   "dependencies": {
     "amortize": "0.2.2",
-    "debounce": "0.0.3",
     "foreach": "2.0.4",
     "format-usd": "^0.2.0",
     "fuzzy-state-search": "0.1.0",

--- a/src/_layouts/sidebar_nav.html
+++ b/src/_layouts/sidebar_nav.html
@@ -1,7 +1,6 @@
 <!-- NAVIGATION -->
 {% set navigation_bar = [
     ('../', 'index', 'Owning a Home'),
-    ('../check-rates/', 'check-rates', 'Check interest rates'),
     ('../loan-options/', 'loan-options', 'Understand loan options'),
     ('../resources/checklist_mortgage_closing.pdf', 'closing-checklist', 'Closing checklist'),
     ('../resources/mortgage_closing_forms.pdf', 'closing-forms', 'Closing forms explainer')

--- a/src/index.html
+++ b/src/index.html
@@ -20,9 +20,10 @@
   <!-- CONTENT -->
   <div class="wrapper index-content">
     <div class="col-8">
+      
+{% if false %}
       <!-- LEFT CONTENT -->
       <div class="wrapper index-left-content">
-
         <div class="col-9">
           <h2>Check interest rates for your situation<sup>BETA</sup></h2>
           <p>If you are shopping for a mortgage, you might be wondering: What interest rates can I expect? Use this tool to see the range of interest rates currently available to borrowers like you.</p>
@@ -33,8 +34,9 @@
           <img class ="rc-home-illu" src="{{ base_url }}static/img/ill-chart.png" alt="Illustration of interest rate chart">
         </div>
       </div> <!-- /.wrapper -->
+{% endif %}
 
-      <div class="wrapper border-sep">
+      <div class="wrapper index-left-content">
 
         <div class="col-6">
           <h2>Starting to think about buying a home?</h2>

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -147,7 +147,11 @@
                             <li>The <strong>interest rate</strong> is usually lower&mdash;by as much as a full percentage point.</li>
                           </ol>
 
-                          <p>Rates vary among lenders, especially for shorter terms. <a href="/owning-a-home/check-rates" target="_blank">Explore rates specific to your situation</a> so you can tell if you're getting a good deal. Always compare official loan offers, called <a href="/askcfpb/146/what-is-a-good-faith-estimate-what-is-a-gfe.html" id="good-faith-link" target="_blank">Good Faith Estimates</a>, before making your decision.</p>
+                          <p>Rates vary among lenders, especially for shorter terms.
+                            {% if false %}
+                            <a href="/owning-a-home/check-rates" target="_blank">Explore rates specific to your situation</a> so you can tell if you're getting a good deal.
+                            {% endif %}
+                             Always compare official loan offers, called <a href="/askcfpb/146/what-is-a-good-faith-estimate-what-is-a-gfe.html" id="good-faith-link" target="_blank">Good Faith Estimates</a>, before making your decision.</p>
 
                           <div class="note">
                             <p class="alert"><strong>Some lenders may offer balloon loans</strong>. Balloon loan monthly payments are low, but you will have to pay a large lump sum when the loan is due. <a href="/askcfpb/104/what-is-a-balloon-loan.html" target="_blank">Learn more about balloon loans</a>.</p>
@@ -239,9 +243,9 @@
                           <p>Your monthly payments are more likely to be stable with a fixed-rate loan, so you might prefer this option if you value certainty about your loan costs over the long term. With a fixed-rate loan, your interest rate and monthly <a href="/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html" target="_blank">principal and interest payment</a> will stay the same. Your <a href="/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html" target="_blank">total monthly payment</a> can still change—for example, if your property taxes, homeowner’s insurance, or mortgage insurance might go up or down.</p>
 
                           <p>Adjustable-rate mortgages (ARMs) offer less predictability but may be cheaper in the short term. You may want to consider this option if, for example, you plan to move again within the initial fixed period of an ARM. In this case, future rate adjustments may not affect you. However, if you end up staying in your house longer than expected, you may end up paying a lot more. In the later years of an ARM, your interest rate <a href="/askcfpb/1949/for-an-adjustable-rate-mortgage-arm-what-are-the-index-and-margin-and-how-do-they-work.html" target="_blank">changes based on the market</a>, and your monthly principal and interest payment <a href="/askcfpb/1965/how-do-mortgage-lenders-calculate-monthly-payments.html" target="_blank">could go up a lot</a>, even double. <a href="/askcfpb/1947/if-i-am-considering-an-adjustable-rate-mortgage-arm-what-should-i-look-out-for-in-the-fine-print.html" target="_blank">Learn more</a>.</p>
-
+                        {% if false %}
                           <p><a href="/owning-a-home/check-rates" target="_blank">Explore rates specific to your situation</a> and see for yourself how the initial interest rate on an ARM compares to the rate on a fixed-rate mortgage.</p>
-
+                        {% endif %}
                     <h3 id="understanding-arms" class="section-heading">Understanding adjustable-rate mortgages (ARMs)</h3>
 
                     <p>Most ARMs have two periods. During the first period, your interest rate is fixed and won’t change. During the second period, your rate goes up and down regularly based on market changes. <a href="/askcfpb/1949/for-an-adjustable-rate-mortgage-arm-what-are-the-index-and-margin-and-how-do-they-work.html" target="_blank">Learn more about how adjustable rates change</a>. Most ARMs have a 30-year <a href="#loan-term-expand-header">loan term</a>.</p>
@@ -318,7 +322,11 @@
 
                     <h3>Choosing the right loan type</h3>
 
-                    <p class="bump">Each loan type is designed for different situations. Sometimes, only one loan type will fit your situation. If multiple options fit your situation, <a href="/owning-a-home/check-rates" target="_blank">try out scenarios</a> and ask lenders to provide several quotes so you can see which type offers the best deal overall.</p>
+                    <p class="bump">Each loan type is designed for different situations. Sometimes, only one loan type will fit your situation. If multiple options fit your situation, 
+                  {% if false %}
+                    <a href="/owning-a-home/check-rates" target="_blank">try out scenarios</a> and 
+                  {% endif %}
+                    ask lenders to provide several quotes so you can see which type offers the best deal overall.</p>
 
                     <div class="wrapper">
                       <section class="col-4 sans">


### PR DESCRIPTION
Links and content removed in a temporary fashion.

Also, this removes the debounce requirement because that change was sitting in my code. It should have been included with https://github.com/cfpb/owning-a-home/pull/265 but it wasn't... debounce isn't being used anywhere that I can see, but feel free to double-check before merging!