### PR TITLE
Sending pass/fail to saucelabs fails if using a proxy for connection

### DIFF
--- a/test/browser_testing/features/environment.py
+++ b/test/browser_testing/features/environment.py
@@ -121,8 +121,17 @@ def after_all(context):
 
         body_content = json.dumps({"passed": not context.failed})
         context.logger.info("Updating sauce job with %s" % body_content)
-        connection = httplib.HTTPConnection("saucelabs.com")
-        connection.request('PUT', '/rest/v1/%s/jobs/%s' %
+        
+        # If a proxy is present then use it, otherwise connect directly to saucelabs
+        http_proxy = os.getenv('http_proxy', None)
+        if http_proxy:
+            if http_proxy.startswith("http://"):
+                http_proxy = http_proxy[7:]
+            connection = httplib.HTTPConnection(http_proxy)
+        else:    
+            connection = httplib.HTTPConnection("saucelabs.com")
+
+        connection.request('PUT', 'http://saucelabs.com/rest/v1/%s/jobs/%s' %
                            (context.sauce_config['username'],
                             context.base.driver.session_id),
                            body_content,


### PR DESCRIPTION
Fixing a bug where the final step to send pass/fail to saucelabs will not work if using a proxy. It will now check if a proxy is present (via the HTTP_PROXY environment variable) and use that if it's present.  Otherwise it'll use the regular direct connection

@OrlandoSoto Can you please review this?  