### PR TITLE
Print styles

### DIFF
--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -41,3 +41,4 @@
 @import "module/form-explainer.less";
 @import "module/no-js.less";
 @import "module/helpers.less";
+@import "module/print.less";

--- a/src/static/css/module/mixins.less
+++ b/src/static/css/module/mixins.less
@@ -65,6 +65,50 @@
     }
 }
 
+/* topdoc
+  name: respond-to-print() (mixin)
+  notes:
+    - "This mixin allows us to easily write styles that target both
+       `@media print` and `.print`."
+  family: cfgov-cf-enhancements
+  patterns:
+    - name: Usage
+      codenotes:
+        - |
+          // Example Less
+          .example {
+              color: @gray;
+
+              .respond-to-print({
+                  color: @black;
+              });
+          }
+
+          // Exports to
+          .example {
+              color: #75787B;
+          }
+          @media print {
+              .example {
+                  color: #101820;
+              }
+          }
+          .print .example {
+              color: #101820;
+          }
+  tags:
+    - cfgov-cf-enhancements
+*/
+
+.respond-to-print(@rules) {
+    @media print {
+        @rules();
+    }
+    .print & {
+        @rules();
+    }
+}
+
 /*
  * link color mixins
  * ==================

--- a/src/static/css/module/print.less
+++ b/src/static/css/module/print.less
@@ -28,4 +28,152 @@
     - cfgov-print
 */
 
-/* print styles here using @respond-to-print mixin */
+// print styles using .respond-to-print mixin
+
+/* ==========================================================================
+   Print styles.
+   Inlined to avoid the additional HTTP request:
+   http://www.phpied.com/delay-loading-your-print-css/
+   ========================================================================== */
+
+@media print {
+  *,
+  *:before,
+  *:after {
+    background: transparent !important;
+    color: #000 !important; /* Black prints faster:
+                               http://www.sanbeiji.com/archives/953 */
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  a,
+  a:visited {
+    text-decoration: underline;
+    border-bottom: 0;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+    display: block;
+    position: relative;
+    top: 0;
+    left: 0;
+    margin: 0;
+    padding: 0;
+    right: 0;
+    width: auto;
+    word-wrap: break-word;
+    white-space: normal;
+  }
+
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+
+  /*
+   * Don't show links that are fragment identifiers,
+   * or use the `javascript:` pseudo protocol
+   */
+
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+
+  /*
+   * Printing Tables:
+   * http://css-discuss.incutio.com/wiki/Printing_Tables
+   */
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+}
+
+/* topdoc
+  name: Hero image print styles
+  family: cfgov-cf-enhancements
+  patterns:
+    - name: #hero-bg-image
+      markup: |
+        <div class="wrapper hero-wrapper">
+          <div class="col-7">
+            <h1>Owning a Home</h1>
+            <h2>We’re here to help you with your home buying process. Just starting out? Learn what to expect and how to get a great deal. About to close? A checklist makes it less stressful.</h2>
+          </div>
+        </div>
+  tags:
+    - cfgov-cf-enhancements
+*/
+
+#hero-bg-image {
+  .respond-to-print({
+    background-image: none; 
+    background-color: transparent;
+    border-bottom: 1px solid @gray-50;
+  });
+}
+
+/* topdoc
+  name: PDF Link print styles
+  family: cfgov-cf-enhancements
+  patterns:
+    - name: .superheader
+      markup: |
+        <a class="pdf-link pdf" href="/owning-a-home/resources/checklist_mortgage_closing.pdf">Get the closing checklist</a>
+  tags:
+    - cfgov-cf-enhancements
+*/
+
+.pdf-link {
+  .respond-to-print({
+    display: inline;
+  });
+}
+
+/* topdoc
+  name: Header slug print styles
+  family: cfgov-cf-enhancements
+  patterns:
+    - name: .tabbed-heading
+      markup: |
+        <header class="tabbed-header tabbed-pad-top">
+        <h3 class="subhead tabbed-heading">Stay tuned</h3>
+      </header>
+  tags:
+    - cfgov-cf-enhancements
+*/
+
+.tabbed-heading {
+  .respond-to-print({
+    border-top-color: @gray-50;
+  });
+}

--- a/src/static/css/module/print.less
+++ b/src/static/css/module/print.less
@@ -1,0 +1,31 @@
+/* ==========================================================================
+   cfgov-refresh
+   Print
+   ========================================================================== */
+
+
+/* topdoc
+  name: Print pages
+  family: cfgov-print
+  notes:
+    - "Print pages are barebones printer friendly pages which are also sometimes
+       used as the source to generate PDF's through PDF creation software."
+    - "The `.print` class acts a styling hook. When using the
+       `.respond-to-print()` mixin, all stlyes will be nested under both
+       `@media print` and `.print`."
+  patterns:
+    - name: Usage
+      markup: |
+        <div class="print">
+            <h1 class="superheader">
+                I am a green superheader
+            </h1>
+        </div>
+      notes:
+        - "To trigger a print page simply add the `.print` class to a containing
+           element."
+  tags:
+    - cfgov-print
+*/
+
+/* print styles here using @respond-to-print mixin */


### PR DESCRIPTION
Basic print styles:

* Uses [print mixin from Capital Framework](https://github.com/cfpb/cfgov-refresh/issues/248)
* Includes HTML5 Boilerplate print styles
* Removes background colors and images
* Changes text, link, border colors to grayscale for faster/cheaper printing
* Adds link href after link elements

Screenshots of the OaH landing page with these styles applied. Note that layout remains fluid and unchanged from the default responsive styling:

![screen shot 2015-02-17 at 5 37 13 pm](https://cloud.githubusercontent.com/assets/702526/6238772/b89b3f72-b6cb-11e4-915a-3ed547d08db0.png)
![screen shot 2015-02-17 at 5 37 23 pm](https://cloud.githubusercontent.com/assets/702526/6238771/b89a3762-b6cb-11e4-983e-186c6d0e3c86.png)

I'd love feedback from designers on how to improve future iterations of these styles.