### PR TITLE
Worksheet summary callouts

### DIFF
--- a/src/static/css/module/typography.less
+++ b/src/static/css/module/typography.less
@@ -191,3 +191,1083 @@ ul > li {
   -webkit-font-smoothing: antialiased;
 }
 
+/* ==========================================================================
+   Capital Framework
+   Advanced Typography
+   ========================================================================== */
+
+
+/* topdoc
+  name: Theme variables
+  family: cf-typography
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+  - name: Colors
+    codenotes:
+      - |
+        @pull-quote_body
+        @pull-quote_citation
+        @micro-copy-text
+        @date-text
+        @category-slug-text
+        @category-slug-hover
+        @header-slug-thin-border
+        @header-slug-thick-border
+        @padded-header-text
+        @padded-header-bg
+        @padded-header-border
+        @fancy-slug-text
+        @fancy-slug-bg
+        @fancy-slug-border
+        @meta-header-border
+        @jump-link__bg
+        @jump-link__bg-border
+        @list__branded-bullet
+  - name: Sizing
+    codenotes:
+      - |
+        @...
+  tags:
+  - cf-typography
+  - less
+*/
+
+// Color variables
+
+// .pull-quote
+@pull-quote_body:               #895983;
+@pull-quote_citation:           lighten(#895983, 15%);
+
+// .micro-copy
+@micro-copy-text:               lighten(#895983, 15%);
+
+// .date
+@date-text:                     lighten(#895983, 15%);
+
+// .category-slug
+@category-slug-text:            darken(#895983, 15%);
+@category-slug-hover:           #c7336e;
+
+// .header-slug
+@header-slug-thin-border:       #c7336e;
+@header-slug-thick-border:      #3a8899;
+
+// .padded-header
+@padded-header-text:            darken(#895983, 15%);
+@padded-header-bg:              lighten(#905c8a, 45%);
+@padded-header-border:          darken(#895983, 15%);
+
+// .fancy-slug
+@fancy-slug-text:               #905c8a;
+@fancy-slug-bg:                 lighten(#905c8a, 45%);
+@fancy-slug-border:             #905c8a;
+
+// .meta-header
+@meta-header-border:            #905c8a;
+
+// .jump-link
+@jump-link__bg:                 lighten(#905c8a, 45%);
+@jump-link__bg-border:          #905c8a;
+
+// .list__branded
+@list__branded-bullet:          #3a8899;
+
+
+/* topdoc
+ name: Pull quote
+ family: cf-typography
+ patterns:
+   - name: Default pull quote
+     markup: |
+       <aside class="pull-quote">
+           <div class="pull-quote_body">
+               Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+               Cum corrupti tempora nam nihil qui mollitia consectetur
+               corporis nemo culpa dolorum!
+           </div>
+           <footer>
+               <cite class="pull-quote_citation">
+                   - Author Name
+               </cite>
+           <footer>
+       </aside>
+     notes:
+       - "Use a pull quote to highlight excerpts from the current work.
+         This is not to be confused with blockquote which quotes from an
+         external work."
+       - "Since a pull quote is an excerpt and repeats content from the
+         article it's contained within you should use the aside element."
+   - name: Large pull quote
+     markup: |
+       <aside class="pull-quote pull-quote__large">
+           <div class="pull-quote_body">
+               Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+               Cum corrupti tempora nam nihil qui mollitia consectetur
+               corporis nemo culpa dolorum!
+           </div>
+           <footer>
+               <cite class="pull-quote_citation">
+                   - Author Name
+               </cite>
+           <footer>
+       </aside>
+ tags:
+   - cf-typography
+*/
+
+.pull-quote {
+
+   &_body {
+       .h3();
+       // Spacing is based off of the baseline so this margin number has been
+       // eyeballed to be ~24px.
+       margin-bottom: unit(12px / @font-size, em);
+       color: @pull-quote_body;
+   }
+
+   &_citation {
+       .h5();
+       color: @pull-quote_citation;
+   }
+}
+
+.pull-quote__large {
+
+   .pull-quote_body {
+       .h2();
+       // Spacing is based off of the baseline so this margin number has been
+       // eyeballed to be ~30px.
+       margin-bottom: unit(18px / @font-size, em);
+   }
+}
+
+
+/* topdoc
+  name: Micro copy
+  family: cf-typography
+  patterns:
+    - name: Standard micro copy
+      markup: |
+        <p class="micro-copy">
+            Lorem ipsum dolor sit amet
+        </p>
+      codenotes:
+        - .micro-copy
+    - name: Large micro copy
+      markup: |
+        <p class="micro-copy micro-copy__large">
+            Lorem ipsum dolor sit amet
+        </p>
+      codenotes:
+        - .micro-copy
+  tags:
+    - cf-typography
+*/
+
+.micro-copy {
+    color: @micro-copy-text;
+    font-size: unit(14px / @base-font-size-px, em);
+    .webfont-regular();
+
+    &__large {
+        font-size: unit(16px / @base-font-size-px, em);
+    }
+}
+
+
+/* topdoc
+  name: Short description
+  family: cf-typography
+  patterns:
+    - name: .short-desc
+      markup: |
+        <p class="short-desc">I am short description.</p>
+      codenotes:
+        - .short-desc
+    - name: .short-desc__large (modifier)
+      markup: |
+        <p class="short-desc short-desc__large">I am large short description.</p>
+      codenotes:
+        - .short-desc__large
+  tags:
+    - cf-typography
+*/
+
+.short-desc {
+    .webfont-regular();
+
+    &__large {
+        font-size: unit(18px / @base-font-size-px, em);
+    }
+}
+
+
+/* topdoc
+  name: Date
+  family: cf-typography
+  patterns:
+    - name: Default date
+      markup: |
+        <span class="date">
+            Nov 4, 2013
+        </span>
+  tags:
+    - cf-typography
+*/
+
+.date {
+    .h5();
+    color: @date-text;
+    white-space: nowrap;
+}
+
+
+/* topdoc
+  name: Category slug
+  family: cf-typography
+  patterns:
+    - name: Default category slug
+      markup: |
+        <a href="#" class="category-slug">
+            <span class="category-slug_icon cf-icon cf-icon-dialogue"></span>
+            <span class="u-visually-hidden">Category:</span>
+            Consumer finance
+        </a>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .category-slug
+            .category-slug_icon
+            .u-visually-hidden
+      notes:
+        - "We suggest using a .u-visually-hidden element to add more context for
+          screen readers."
+  tags:
+    - cf-typography
+*/
+
+.category-slug {
+    .h4();
+    display: inline-block;
+    // Eyeballed to 20px over h2.
+    margin-bottom: unit(8px / @font-size, em);
+    color: @category-slug-text;
+
+    a& {
+        .u-link__colors(@category-slug-text, @category-slug-hover);
+    }
+
+    &_icon {
+        margin-right: unit(2px / @font-size, em);
+    }
+}
+
+
+/* topdoc
+  name: Header slug
+  family: cf-typography
+  patterns:
+    - name: Default header slug
+      markup: |
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Blog summary
+            </span>
+        </h2>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .header-slug
+            .header-slug_inner
+  tags:
+    - cf-typography
+*/
+
+.header-slug {
+    .h5();
+    margin-bottom: unit(17px / @font-size, em);
+    border-top: 1px solid @header-slug-thin-border;
+
+    &_inner {
+        display: inline-block;
+        padding-top: unit(4px / @font-size, em);
+        margin-top: -3px;
+        border-top: 5px solid @header-slug-thick-border;
+    }
+}
+
+
+/* topdoc
+  name: Padded header
+  family: cf-typography
+  patterns:
+    - name: Default padded header
+      markup: |
+        <h2 class="padded-header">
+            Header
+        </h2>
+      codenotes:
+        - .padded-header
+  tags:
+    - cf-typography
+*/
+
+.padded-header {
+    .h5();
+    // 8px top padding to account for line-height.
+    padding: unit(8px / @font-size, em)
+             unit(10px / @font-size, em);
+    margin-bottom: 0;
+    border-bottom: 1px solid @padded-header-border;
+    background: @padded-header-bg;
+    color: @padded-header-text;
+}
+
+/* topdoc
+  name: Fancy slug
+  family: cf-typography
+  patterns:
+    - name: Default fancy slug
+      markup: |
+        <h2 class="fancy-slug">
+            <span class="fancy-slug_text">
+                <span class="fancy-slug_ribbon-left"></span>
+                Watchroom
+                <span class="fancy-slug_ribbon-right"></span>
+            </span>
+        </h2>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .fancy-slug
+            .fancy-slug_text
+                .fancy-slug_ribbon-left
+                .fancy-slug_ribbon-right
+  tags:
+    - cf-typography
+*/
+
+.fancy-slug {
+    @v-padding: 8px;
+    @ribbon-width: 17px;
+    @ribbon-angle: 33deg;
+
+    .h5();
+    position: relative;
+    // Cut the height in half since we will be adding it back with margin.
+    height: unit(((@font-size / 2) + @v-padding + 1) / @font-size, em);
+    padding: 0 unit(@ribbon-width / @font-size, em);
+    // Add back half of the height to create a space for the text to pull
+    // itself up into.
+    margin-top: unit(((@font-size / 2) + @v-padding + 1) / @font-size, em);
+    // Bottom margin is eyeballed to 15px when considering baseline and line-height.
+    margin-bottom: unit(8px / @font-size, em);
+    border-top: 1px solid @fancy-slug-border;
+    line-height: 1;
+    text-align: center;
+
+    &_text {
+        display: inline-block;
+        position: relative;
+        // Pull the text up up by half of its height so that it is vertically
+        // centered with .fancy-slugs top border. "Height" means half the
+        // font-size plus half the total padding and half the borders.
+        top: unit(((@font-size / 2) + @v-padding + 1) * -1 / @font-size, em);
+        padding: unit(@v-padding / @font-size, em) unit(20px / @font-size, em);
+        border: 1px solid @fancy-slug-border;
+        background: @fancy-slug-bg;
+    }
+
+    // Use :before as the top corner and :after as the bottom corner.
+    &_ribbon-left,
+    &_ribbon-right {
+        display: block;
+        position: absolute;
+        top: -1px;
+        width: unit(@ribbon-width / @font-size, em);
+        height: 100%;
+        border-top: 1px solid @fancy-slug-border;
+        border-bottom: 1px solid @fancy-slug-border;
+
+        .lt-ie9 & {
+            display: none;
+        }
+
+        &:before,
+        &:after {
+                display: block;
+                content: "";
+                position: absolute;
+                z-index: 3;
+                width: unit(@ribbon-width / @font-size, em);
+                height: 50%;
+                background: @fancy-slug-bg;
+                border: 0 solid @fancy-slug-border;
+        }
+    }
+
+    &_ribbon-left {
+        left: unit(-@ribbon-width / @font-size, em);
+        &:before {
+            top: 0;
+            border-left-width: 1px;
+            transform-origin: 0 0;
+            transform: skewX(@ribbon-angle);
+        }
+        &:after {
+            bottom: 0;
+            border-left-width: 1px;
+            transform-origin: 0 100%;
+            transform: skewX(-@ribbon-angle);
+        }
+    }
+
+    &_ribbon-right {
+        right: unit(-@ribbon-width / @font-size, em);
+        &:before {
+            top: 0;
+            right: 0;
+            border-right-width: 1px;
+            transform-origin: 100% 0;
+            transform:  skewX(-@ribbon-angle);
+        }
+        &:after {
+            right: 0;
+            bottom: 0;
+            border-right-width: 1px;
+            transform-origin: 100% 100%;
+            transform:  skewX(@ribbon-angle);
+        }
+    }
+}
+
+/* topdoc
+  name: Meta header
+  family: cf-typography
+  patterns:
+    - name: Default meta header
+      markup: |
+        <div class="meta-header">
+            <span class="meta-header_right date">
+                Nov 4, 2013
+            </span>
+            <a href="#" class="meta-header_left category-slug">
+                <span class="cf-icon cf-icon-credit-card"></span>
+                Consumer finance
+            </a>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .meta-header
+            .meta-header_right
+            .meta-header_left
+      notes:
+        - ".meta-header_right should come first in the markup so that when it
+          floats to the right it will appear on the same line as .meta-header_left."
+        - "Note that the example shows .meta-header_left using the
+          .category-slug pattern and .meta-header_right using the .date pattern
+          but you could use other patterns in place of them. Or you can even
+          swap them so that date is attached to .meta-header_left and
+          .category-slug is attacked to .meta-header_right."
+    - name: Alternate meta header arrangements
+      markup: |
+        <div class="meta-header">
+            <a href="#" class="meta-header_right category-slug">
+                <span class="cf-icon cf-icon-credit-card"></span>
+            </a>
+            <span class="meta-header_left date">
+                Nov 4, 2013
+            </span>
+        </div>
+        <br>
+        <div class="meta-header">
+            <a href="#" class="meta-header_left category-slug">
+                <span class="cf-icon cf-icon-credit-card"></span>
+                Consumer finance
+            </a>
+        </div>
+      notes:
+        - "Just some random variations to show off what you could do."
+  tags:
+    - cf-typography
+*/
+
+.meta-header {
+    padding-bottom: unit(8px / @base-font-size-px, em);
+    margin-bottom: unit(10px / @base-font-size-px, em);
+    border-bottom: 1px solid @meta-header-border;
+}
+
+.meta-header_left {
+    margin-bottom: 0;
+}
+
+.meta-header_right {
+    display: block;
+    margin-bottom: 0;
+    .respond-to-min(600px, {
+        .u-right();
+        display: inline-block;
+    });
+}
+
+
+/* topdoc
+  name: Links with icons
+  family: cf-typography
+  notes:
+    - "Styles to enable adding an icon to a link and preventing the link's
+       underline from extending under the icon."
+    - "For the underlined icon prevention to work, you must wrap the link text
+       with a `span.icon-link_text`. There can be no whitespace between the text
+       and the opening and closing span tags."
+  patterns:
+    - name: Default link with icon
+      markup: |
+        <p>
+            For more information, email
+            <a class="icon-link icon-link__mail" href="#">
+                <span class="icon-link_text">john.smith@cfpb.gov</span>
+            </a>.
+            Alternatively, you can
+            <a class="icon-link icon-link__download" href="#">
+                <span class="icon-link_text">download the info sheet</span>
+            </a>.
+            Oh, you might also want to visit this
+            <a class="icon-link icon-link__external-link" href="#">
+                <span class="icon-link_text">other organization's website</span>
+            </a> for further details.
+        </p>
+        <a class="icon-link icon-link__right" href="#">
+            Visit another section of our site
+        </a>
+      notes:
+        - "The modifier names match the cf-icon names of commonly-used icons."
+        - "Icons appear to the right of a link, by default."
+    - name: Links with icons on the left (modifier)
+      markup: |
+        <a class="icon-link icon-link__mail icon-link__before" href="#">
+            <span class="icon-link_text">john.smith@cfpb.gov</span>
+        </a><br>
+        <a class="icon-link icon-link__phone icon-link__before" href="#">
+            (123) 456-7890
+        </a>
+      notes:
+        - "Simply add the `.icon-link__before` modifier to place the icon before
+           the link text."
+        - "You can omit the `span.icon-link_text` wrapper if you do not need
+           an underline on a particular link."
+    - name: Non-wrapping icon links
+      markup: |
+        <p>
+            For more information, email
+            <a class="icon-link icon-link__mail icon-link__no-wrap" href="#">
+                <span class="icon-link_text">john.smith@cfpb.gov</span>
+            </a>.
+        </p>
+      notes:
+        - "Warning: Icons added to inline links can sometimes break onto the
+           next line. If you want to prevent this, you can add the `__no-wrap`
+           modifier to `.icon-link`."
+  tags:
+    - cf-typography
+*/
+
+.icon-link {
+    border-bottom-width: 0;
+    position: relative;
+
+    &_text {
+        border-bottom-width: 1px;
+        border-bottom-style: inherit;
+    }
+
+    &:before,
+    &:after {
+        .cf-icon();
+        margin-right: 1px;
+        margin-left: 1px;
+    }
+
+    &__download:after,
+    &__download&__before:before {
+        // Inserts the cf-icon-download glyph.
+        content: "\e406";
+    }
+
+    &__email:after,
+    &__email&__before:before {
+        // Inserts the cf-icon-email glyph.
+        content: "\e302";
+    }
+
+    &__external-link:after,
+    &__external-link&__before:before {
+        // Inserts the cf-icon-external-link glyph.
+        content: "\e610";
+    }
+
+    &__fax:after,
+    &__fax&__before:before {
+        // Inserts the cf-icon-fax glyph.
+        content: "\e310";
+    }
+
+    &__left:after,
+    &__left&__before:before {
+          // Inserts the cf-icon-left glyph.
+          content: "\e000";
+      }
+
+    &__mail:after,
+    &__mail&__before:before {
+        // Inserts the cf-icon-mail glyph.
+        content: "\e304";
+    }
+    
+    &__pdf:after,
+    &__pdf&__before:before {
+        // Inserts the cf-icon-pdf glyph.
+        content: "\e402";
+    }
+
+    &__pdf:after,
+    &__pdf&__before:before {
+        // Inserts the cf-icon-pdf glyph.
+        content: "\e402";
+    }
+
+    &__phone:after,
+    &__phone&__before:before {
+        // Inserts the cf-icon-phone glyph.
+        content: "\e306";
+    }
+
+    &__right:after,
+    &__right&__before:before {
+        // Inserts the cf-icon-right glyph.
+        content: "\e002";
+    }
+
+    // New icon modifiers must be added ABOVE this line.
+
+    &__before {
+        &:after {
+            content: '';
+        }
+    }
+
+    &__no-wrap {
+        white-space: nowrap;
+    }
+}
+
+/* topdoc
+  name: Styled link
+  family: cf-typography
+  patterns:
+    - name: .styled-link
+      markup: |
+        <a class="styled-link" href="#">
+            Default styled link
+        </a>
+      codenotes:
+        - .styled-link
+  tags:
+    - cf-typography
+*/
+
+.styled-link {
+    @font-size: 16px;
+
+    border-bottom-width: 1px;
+    .webfont-medium();
+    font-size: unit(@font-size / @base-font-size-px, em);
+}
+
+
+/* topdoc
+  name: Jump link
+  family: cf-typography
+  patterns:
+    - name: .jump-link
+      markup: |
+        <a class="jump-link" href="#">
+            <span class="jump-link_text">Default jump link</span>
+        </a>
+      codenotes:
+        - .jump-link
+    - name: .jump-link__large (modifier)
+      markup: |
+        <a class="jump-link jump-link__large" href="#">
+            <span class="jump-link_text">Large jump link</span>
+        </a>
+      codenotes:
+        - .jump-link__large
+      notes:
+        - "18px font-size, compared to the default of 16px"
+    - name: .jump-link__<icon> (modifier)
+      markup: |
+        <a class="jump-link jump-link__right" href="#">
+            <span class="jump-link_text">Jump link using the right icon from cf-icons</span>
+        </a>
+      codenotes:
+        - .jump-link__<icon>
+      notes:
+        - ".jump-link extends .icon-link, so all that is needed to add an icon
+           to a jump link is to add a modifier with the icon's name."
+    - name: .jump-link__before (modifier)
+      markup: |
+        <a class="jump-link jump-link__left jump-link__before" href="#">
+            <span class="jump-link_text">Jump link with icon on left</span>
+        </a>
+      codenotes:
+        - .jump-link__<icon>.jump-link__before
+      notes:
+        - "Jump links can also have icons before the text, like icon links."
+    - name: .jump-link__bg (modifier)
+      markup: |
+        <a class="jump-link jump-link__bg" href="#">
+            <span class="jump-link_text">Jump link with grey background and
+                solid borders on small screens</span>
+        </a>
+      codenotes:
+        - .jump-link__bg
+  tags:
+    - cf-typography
+*/
+
+.jump-link {
+    .webfont-medium();
+    font-size: unit(16px / @base-font-size-px, em);
+
+    .icon-link();
+
+    &__large {
+        font-size: unit(18px / @base-font-size-px, em);
+    }
+
+    .respond-to-max(599px, {
+        .block-link();
+
+        &:after {
+            position: absolute;
+            margin-bottom: -0.625em;
+            right: 0;
+            bottom: 50%;
+            text-align: right;
+        }
+        
+        &__before {
+            padding-left: 1.25em;
+            
+            &:before {
+                position: absolute;
+                margin-bottom: -0.625em;
+                bottom: 50%;
+                left: 0;
+            }
+        }
+
+        &_text {
+            border-bottom-width: 0;
+        }
+
+        &__bg {
+            background: @jump-link__bg;
+            border: solid @jump-link__bg-border;
+            border-width: 1px 0;
+            padding: unit(10px / @base-font-size-px, em) 1.25em unit(10px / @base-font-size-px, em) 1em;
+            &:after {
+                right: 1em;
+            }
+            &:before {
+                left: unit(10px / @base-font-size-px, em);
+            }
+        }
+    });
+}
+
+
+/* topdoc
+  name: Block link
+  family: cf-typography
+  patterns:
+    - name: .block-link
+      markup: |
+        <a class="block-link" href="#">
+            Default block link
+        </a>
+      codenotes:
+        - .block-link
+      notes:
+        - "Convert a standard inline link to a block-level element with padding,
+           background, and borders."
+        - "Primarily used within a max-width 599px media query (see .jump-link
+           and .list__links)."
+  tags:
+    - cf-typography
+*/
+
+.block-link {
+    @link-text: #fff;
+    box-sizing: border-box;
+    display: block;
+    padding: unit(10px / @base-font-size-px, em) 1.25em unit(10px / @base-font-size-px, em) 0;
+    border: dotted @link-text;
+    border-width: 1px 0;
+    margin-right: 0;
+    // 100% width is needed when .jump-link is applied to a <button>.
+    width: 100%;
+    text-align: left;
+}
+
+
+/* topdoc
+  name: Unstyled list modifier
+  family: cf-typography
+  patterns:
+    - name: Default example
+      markup: |
+        <ul class="list list__unstyled">
+            <li class="list_item">
+                <a class="list_link">List item 1</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 2</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 3</a>
+            </li>
+        </ul>
+      codenotes:
+        - .list.list__unstyled
+  tags:
+    - cf-typography
+*/
+
+.list__unstyled {
+    padding-left: 0;
+    list-style-type: none;
+
+    // This is needed for dd elements.
+    .list_item {
+        margin-left: 0;
+    }
+}
+
+
+/* topdoc
+  name: Spaced list modifier
+  family: cf-typography
+  patterns:
+    - name: Default example
+      markup: |
+        <ul class="list list__spaced">
+            <li class="list_item">
+                <a class="list_link">List item 1</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 2</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 3</a>
+            </li>
+        </ul>
+      codenotes:
+        - .list.list__spaced
+  tags:
+    - cf-typography
+*/
+
+.list__spaced {
+    .list_item + .list_item {
+        margin-top: unit(24px / @base-font-size-px, em);
+    }
+}
+
+
+/* topdoc
+  name: Spaced list item modifier
+  family: cf-typography
+  patterns:
+    - name: Default example
+      markup: |
+        <ul class="list">
+            <li class="list_item">
+                <a class="list_link">List item 1</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 2</a>
+            </li>
+            <li class="list_item list_item__spaced">
+                <a class="list_link">List item 3</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 4</a>
+            </li>
+        </ul>
+  tags:
+    - cf-typography
+*/
+
+.list_item__spaced {
+    margin-top: unit(24px / @base-font-size-px, em);
+}
+
+
+/* topdoc
+  name: Horizontal list modifier
+  family: cf-typography
+  patterns:
+    - name: Default example
+      markup: |
+        <ul class="list list__horizontal">
+            <li class="list_item">
+                <a class="list_link">List item 1</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 2</a>
+            </li>
+            <li class="list_item">
+                <a class="list_link">List item 3</a>
+            </li>
+        </ul>
+  tags:
+    - cf-typography
+*/
+
+.list__horizontal {
+    padding-left: 0;
+
+    .list_item {
+        .u-inline-block();
+    }
+
+    .list_item {
+        // Assuming a natural space of 4px between inline block items
+        // then the space between would be 8px (4px natural + 4px added).
+        margin-right: unit(4px / @base-font-size-px, em);
+        margin-left: 0;
+    }
+}
+
+
+/* topdoc
+  name: Icon list modifier
+  family: cf-typography
+  notes:
+    - "Set up a list with icons on the left, in place of bullets."
+    - "Will need some more work to allow lines to wrap."
+  patterns:
+    - name: Default example
+      markup: |
+        <ul class="list list__icons">
+            <li class="list_item">
+                <span class="cf-icon cf-icon-email list_icon"></span>
+                List item 1
+            </li>
+            <li class="list_item">
+                <span class="cf-icon cf-icon-phone list_icon"></span>
+                List item 1
+            </li>
+            <li class="list_item">
+                <span class="cf-icon cf-icon-fax list_icon"></span>
+                List item 1
+            </li>
+        </ul>
+  tags:
+    - cf-typography
+*/
+
+.list__icons {
+    .list__unstyled();
+
+    .list_icon {
+        width: 1.5em;
+        text-align: center;
+    }
+}
+
+
+/* topdoc
+ name: Custom bullet mixin
+ family: cf-typography
+ patterns:
+   - name: Custom bullet
+     codenotes:
+       - ".custom-bullet(@text, @color, @offset, @size, @font, @type)"
+     notes:
+       - "Displays custom bullets to the left of specified elements as :before pseudo elements."
+       - "To use, pass this mixin values for the bullet to be displayed: text, color, font size,
+          and offset (distance away from the parent element the bullet should appear). 
+          Font family parameter is optional and defaults to inherited."
+       - "Bullets are absolutely positioned outside of their parent's flow,
+          so they will not receive certain properties applied to the parent 
+          (borders, text-decoration, etc)."
+       - "By default, custom bullets hang outside of their parent's content box 
+          (in the margin or padding if there is any). If you want the bullets to align 
+          with the left boundary of the parent's content box, give the parent a 
+          left margin value equal to the offset."
+ tags:
+   - cf-typography
+*/
+
+.custom-bullet(@text, @color, @offset, @size, @font:inherit) {
+    list-style-type: none;
+    position: relative;
+
+  &:before {
+    content: @text;
+    font-family: @font;
+    font-size: @size;
+    color: @color;
+    line-height: 1;
+    position: absolute;
+    left: -@offset;
+  }
+}
+
+
+/* topdoc
+ name: Branded list modifier
+ family: cf-typography
+ patterns:
+   - name: Branded list
+     markup: |
+       <ul class="list__branded">
+           <li>First item</li>
+           <li>Second item</li>
+           <li>Third item</li>
+       </ul>
+     codenotes:
+       - ".list__branded"
+     notes:
+       - "Uses .custom-bullet mixin to generate custom main-brand-color square bullets."
+ tags:
+   - cf-typography
+*/
+
+.list__branded {
+    li, 
+    .list_item {
+        @font-size: 22px;
+        @offset: unit(19px / @font-size, em);
+        @size: unit(22px / @base-font-size-px, em);
+        .webfont-regular();
+        .custom-bullet(@text:"\25AA", @color: @list__branded-bullet, @offset: @offset, @size: @size);
+    }
+}
+
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/src/static/js/templates/prepare-worksheets/page-summary.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary.hbs
@@ -39,16 +39,16 @@
     <div class="summary content-l content-l__main">
         <div class="content-l_col content-l_col-1-2">
             <section class="summary-callout">
-              <h2>Ready to continue?</h2>
-              <p>
+              <h4>Ready to continue?</h4>
+              <p class="short-desc">
               The next step is to explore how much it will cost to buy a home that meets your goals, and whether buying makes sense financially.  For most people, owning a home will end up being more expensive than their current rental.  Before you start house shopping in earnest, it’s a good idea to get a clear sense for how much buying will cost, so you can decide for yourself if the benefits are worth the cost.
               </p>
             </section>
         </div>
         <div class="content-l_col content-l_col-1-2">
             <section class="summary-callout">
-              <h2>Not ready to buy?</h2>
-              <p>
+              <h4>Not ready to buy?</h4>
+              <p class="short-desc">
               Are there red flags in your situation, or risks you’re not ready to accept?   That’s ok.  Sometimes, the smartest home buying decision is deciding not to buy – at least not right now.  Consider pursuing the alternatives you identified, so that you can meet some of your goals right away.  Or, consider working to build a larger financial cushion so you will be better able to accept the risks of homeownership when the time is right for you.
               </p>
             </section>

--- a/src/static/js/templates/prepare-worksheets/page-summary.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary.hbs
@@ -45,7 +45,7 @@
               </p>
             </section>
         </div>
-        <div class="content-l_col content-l_col-1-2">
+        <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
             <section class="summary-callout">
               <h4>Not ready to buy?</h4>
               <p class="short-desc">

--- a/src/static/js/templates/prepare-worksheets/page-summary.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary.hbs
@@ -33,7 +33,9 @@
             </section>
         </div>
     </div>
+</div>
 
+<div class="block__border-top block__padded-top">
     <div class="summary content-l content-l__main">
         <div class="content-l_col content-l_col-1-2">
             <section class="summary-callout">
@@ -53,7 +55,4 @@
         </div>
     </div>
 
-    
-
-    
 </div>

--- a/src/static/js/templates/prepare-worksheets/page-summary.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary.hbs
@@ -33,5 +33,27 @@
             </section>
         </div>
     </div>
+
+    <div class="summary content-l content-l__main">
+        <div class="content-l_col content-l_col-1-2">
+            <section class="summary-callout">
+              <h2>Ready to continue?</h2>
+              <p>
+              The next step is to explore how much it will cost to buy a home that meets your goals, and whether buying makes sense financially.  For most people, owning a home will end up being more expensive than their current rental.  Before you start house shopping in earnest, it’s a good idea to get a clear sense for how much buying will cost, so you can decide for yourself if the benefits are worth the cost.
+              </p>
+            </section>
+        </div>
+        <div class="content-l_col content-l_col-1-2">
+            <section class="summary-callout">
+              <h2>Not ready to buy?</h2>
+              <p>
+              Are there red flags in your situation, or risks you’re not ready to accept?   That’s ok.  Sometimes, the smartest home buying decision is deciding not to buy – at least not right now.  Consider pursuing the alternatives you identified, so that you can meet some of your goals right away.  Or, consider working to build a larger financial cushion so you will be better able to accept the risks of homeownership when the time is right for you.
+              </p>
+            </section>
+        </div>
+    </div>
+
+    
+
     
 </div>


### PR DESCRIPTION
## Additions
* Typography styles from Capital Framework
* Content and markup for summary page callouts

## Changes from Design
* Note that the border between 2 columns styling that is part of Capital Framework and OAH has padding above and below it, unlike comp
* Comp has call to action links, content doc did not include these as there are no places to send folks yet :) These can be added easily if content changes.

## Testing
* Visual QA performed on all local OaH pages except Rate Checker (I gotta add the API links I know I know). Type styles unaffected by adding CF typography CSS.

## Screenshots
### Small screen stacked style
![screen shot 2015-02-19 at 4 38 20 pm](https://cloud.githubusercontent.com/assets/702526/6276588/eef05ff4-b855-11e4-9fe2-f4fa6a2dfb61.png)

### Large screen 2-col style
![screen shot 2015-02-19 at 4 40 53 pm](https://cloud.githubusercontent.com/assets/702526/6276617/18f923d0-b856-11e4-87e8-8b9e668e6651.png)

## Selfie
![selfie-0](http://i.imgur.com/so8O5vj.gif)


## Review
* @virginiacc 
* @huetingj 
* @stephanieosan 
