### PR TITLE
Worksheet "Learn more" text

### DIFF
--- a/src/static/js/modules/prepare-worksheets/worksheet-config.js
+++ b/src/static/js/modules/prepare-worksheets/worksheet-config.js
@@ -144,21 +144,21 @@ this.worksheetDefaults = {
           "text":"I want to build wealth in the form of equity",
           "grade":null,
           "altText":"??",
-          "explanation":"Learn more: In the long term, owning a home can be a great way to build wealth.  However, it’s important to know that during the first several years of a mortgage, <a href=#>most of your payment goes to interest, not equity</a>.  Also, remember that if home prices go down instead of up – as they did in 2008-2012 – you could lose all of your equity, including your down payment.",
+          "explanation":"<strong>Learn more:</strong> In the long term, owning a home can be a great way to build wealth.  However, it’s important to know that during the first several years of a mortgage, <a href=#>most of your payment goes to interest, not equity</a>.  Also, remember that if home prices go down instead of up – as they did in 2008-2012 – you could lose all of your equity, including your down payment.",
           "deletable": false
         },
         {
           "text":"I believe I can buy a nicer home for the same cost as my rent",
           "grade":null,
           "altText":"??",
-          "explanation":"Learn more: This is often true.  However, it’s important to factor in the total costs of ownership – including insurance, taxes, maintenance, and discretionary improvements – as well as increases in other costs, such as commuting, that may result from buying.  And depending on the real estate market, sometimes renting can actually be cheaper.",
+          "explanation":"<strong>Learn more:</strong> This is often true.  However, it’s important to factor in the total costs of ownership – including insurance, taxes, maintenance, and discretionary improvements – as well as increases in other costs, such as commuting, that may result from buying.  And depending on the real estate market, sometimes renting can actually be cheaper.",
           "deletable": false
         },
         {
           "text":"I want to save money on my taxes with the mortgage deduction",
           "grade":null,
           "altText":"??",
-          "explanation":"Learn more: You can only claim the mortgage interest tax deduction if you itemize your deductions.  For a typical $200,000 mortgage at 4.5%, you’d be able to deduct about $8900 for interest in the first year, and less in future years.  The standard deduction for a married couple is $12,600 in tax year 2015, so unless that couple has at least $4700 in other deductions, having a mortgage won’t lower their taxes.  For heads of household, the standard deduction is $9,250, and for singles it is $6,300.",
+          "explanation":"<strong>Learn more:</strong> You can only claim the mortgage interest tax deduction if you itemize your deductions.  For a typical $200,000 mortgage at 4.5%, you’d be able to deduct about $8900 for interest in the first year, and less in future years.  The standard deduction for a married couple is $12,600 in tax year 2015, so unless that couple has at least $4700 in other deductions, having a mortgage won’t lower their taxes.  For heads of household, the standard deduction is $9,250, and for singles it is $6,300.",
           "deletable": false
         }
       ]

--- a/src/static/js/templates/prepare-worksheets/input-graded.hbs
+++ b/src/static/js/templates/prepare-worksheets/input-graded.hbs
@@ -14,6 +14,11 @@
       <div class="input-with-btns_input">
         <input type="text" value="{{input.text}}" placeholder="{{placeholder}}">
       </div>
+      {{#if input.explanation}}
+      <div class="input-explanation block__sub">
+        <p>{{{input.explanation}}}</p>
+      </div>
+      {{/if}}
     </section>
   </div>
 </section>


### PR DESCRIPTION
## Additions
* Explanation text is output under each input field if it's part of the config data.
* "Learn more" text at the beginning of each explanation is bolded.

## Changes from Design
* The content doc only had explanation text for the Financial Goals. If more explanation text is written, it only has to be added to the worksheet-config.js file explanation field and it will show up on page 1.

## Screenshots
#### Financial Goals Explanation Text
![screen shot 2015-02-20 at 11 54 10 am](https://cloud.githubusercontent.com/assets/702526/6305302/2bfc7976-b8f8-11e4-9ac7-e61c590caaa2.png)

## Review
* @virginiacc 
* @huetingj 
* @stephanieosan 
