### PR TITLE
Worksheet expandables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you already have these modules installed, [skip ahead to Sheer](#sheer-elasti
 	$ brew install elasticsearch
 	```
 
-2. Clone the sheer GitHub project:
+2. Clone the sheer GitHub project to wherever you keep your projects (not inside Owning a Home):
 	```
 	$ git clone https://github.com/cfpb/sheer.git
 	```

--- a/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
+++ b/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
@@ -6,7 +6,8 @@ var _worksheet = require( './worksheet-controller' );
 var config = require( './worksheet-config' ); 
 var Handlebars = require("hbsfy/runtime");
 var $ = require('jquery');
-
+require('jquery-easing');
+require('cf-expandables');
 
 // DOM references.
 var _worksheetsDOM = document.querySelector('.page-contents');

--- a/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
+++ b/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
@@ -6,8 +6,7 @@ var _worksheet = require( './worksheet-controller' );
 var config = require( './worksheet-config' ); 
 var Handlebars = require("hbsfy/runtime");
 var $ = require('jquery');
-require('jquery-easing');
-require('cf-expandables');
+
 
 // DOM references.
 var _worksheetsDOM = document.querySelector('.page-contents');

--- a/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
+++ b/src/static/js/modules/prepare-worksheets/prepare-worksheets.js
@@ -91,6 +91,7 @@ function _loadPage(page) {
     break;
   }
   _updateNavigationState();
+  $('.expandable').expandable();
 }
 
 /* // TEMP - DEBUG - display worksheet data in console.

--- a/src/static/js/modules/prepare-worksheets/worksheet-config.js
+++ b/src/static/js/modules/prepare-worksheets/worksheet-config.js
@@ -169,21 +169,21 @@ this.worksheetDefaults = {
             {  
                 "text":"There is chance I might move within the next few years",
                 "grade":null,
-                "altText":"Renters have more flexibility. It can be risky and expensive to buy if you end up needing to move again within a few years.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             },
             {  
                 "text":"My current employment is short-term or unstable",
                 "grade":null,
-                "altText":"Owning a home is a long-term financial commitment. If you’re not confident that you’ll be able to continue earning at a similar level for the foreseeable future, it might make more sense to keep renting.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             },
             {  
                 "text":"I find fixing things and doing yardwork to be a real hassle",
                 "grade":null,
-                "altText":"In a lot of ways, it’s simpler and more financially predictable to rent.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             }
@@ -195,21 +195,21 @@ this.worksheetDefaults = {
             {  
                 "text":"My home value could decline and I could lose my equity",
                 "grade":null,
-                "altText":"You could even find yourself owing more than your home is worth. In 2008-2012, house prices declined dramatically nationwide, with up to X% declines in some areas.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             },
             {  
                 "text":"Major repairs can be urgent, expensive, and unexpected",
                 "grade":null,
-                "altText":"When the furnace springs a leak or a tree falls on the roof, these aren’t repairs that you can wait to make. New homeowners consistently say that they were surprised how much maintenance costs.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             },
             {  
                 "text":"Minor repairs add up quickly, in terms of time and money",
                 "grade":null,
-                "altText":"Think of all the little things that you are used to calling your landlord to deal with: a cracked window, a broken dishwasher, or a clogged toilet. As a homeowner, you will either have to fix these yourself or call and pay for a professional.",
+                "altText":"",
                 "explanation":"",
                 "deletable": false
             }

--- a/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
@@ -9,6 +9,21 @@
               <div class="u-mt20 u-mb20">
                 <div>
                   <h4>{{text}}</h4>
+                
+                  <div class="expandable">
+                    <a href="#" class="expandable_target">
+                        <span class="expandable_cue-open">
+                            <span class="cf-icon cf-icon-plus-round"></span>&nbsp;See your alternative
+                        </span>
+                        <span class="expandable_cue-close">
+                            <span class="cf-icon cf-icon-minus-round"></span>&nbsp;Hide your alternative
+                        </span>
+                    </a>
+                    <div class="expandable_content">
+                        <p class="short-desc">{{altText}}</p>
+                    </div>
+                  </div>
+
                 </div>
               </div>
             </div>

--- a/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
@@ -10,6 +10,7 @@
                 <div>
                   <h4>{{text}}</h4>
                 
+                {{#if altText}}
                   <div class="expandable">
                     <a href="#" class="short-desc expandable_target">
                         <span class="expandable_cue-open">
@@ -23,6 +24,7 @@
                         <p class="short-desc block__sub block__flush-bottom">{{altText}}</p>
                     </div>
                   </div>
+                {{/if}}
 
                 </div>
               </div>

--- a/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
@@ -11,7 +11,7 @@
                   <h4>{{text}}</h4>
                 
                   <div class="expandable">
-                    <a href="#" class="expandable_target">
+                    <a href="#" class="short-desc expandable_target">
                         <span class="expandable_cue-open">
                             <span class="cf-icon cf-icon-plus-round"></span>&nbsp;See your alternative
                         </span>
@@ -20,7 +20,7 @@
                         </span>
                     </a>
                     <div class="expandable_content">
-                        <p class="short-desc">{{altText}}</p>
+                        <p class="short-desc block__sub block__flush-bottom">{{altText}}</p>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Additions
* Adds cf-expandables component to JavaScript vendor modules (JS + Less)
* Adds cf-expandables component as a dependency in prepare-worksheets.js so we can use expandables
* Triggers expandables js for worksheets page load so we can use it in our JS templates
* Adds basic expandables link pattern to summary page for alternatives

## Changes from Design
* This summary page is still under development by @virginiacc to match the design comps so the only styling here is for the expandables links + paragraph content themselves. 

## Review
* @virginiacc 
* @huetingj: let me know if the open state is ok, as I didn't see one in the .ai file, ditto for the "Hide your alternative" copy

## Screenshot
### Alternatives expandables: top is the open state, bottom is the closed state
![screen shot 2015-02-20 at 4 27 50 pm](https://cloud.githubusercontent.com/assets/702526/6309692/dba9f5cc-b91d-11e4-8897-12352928ac09.png)
