### PR TITLE
Worksheet priority buttons: mobile stacking 'n' more

### DIFF
--- a/src/prepare-worksheets/index.html
+++ b/src/prepare-worksheets/index.html
@@ -18,11 +18,11 @@
       <section class="type-details">
        
         <nav class="block block__padded-top block__border-top">
-          <button class="btn btn__disabled btn-worksheet-prev">
+          <button class="btn btn__disabled btn__super btn-worksheet-prev">
             <span class="btn_icon__left cf-icon cf-icon-left"></span>
             Back
           </button>
-          <button class="btn btn__disabled btn-worksheet-next">
+          <button class="btn btn__disabled btn__super btn-worksheet-next">
             Next
             <span class="btn_icon__right cf-icon cf-icon-right"></span>
           </button>

--- a/src/static/css/module/prepare-worksheets.less
+++ b/src/static/css/module/prepare-worksheets.less
@@ -112,6 +112,10 @@
   }
 }
 
+.input-explanation {
+  clear: both;
+}
+
 // Preparation worksheets goals, risks, red flag icon colors.
 .prepare-worksheet .cf-icon-approved-round {
   color: @green;

--- a/src/static/css/module/prepare-worksheets.less
+++ b/src/static/css/module/prepare-worksheets.less
@@ -42,6 +42,15 @@
   .respond-to-min(801px, {
     width: 60%;
   });
+  .respond-to-min(960px, {
+    width: 68%;
+  });
+  .respond-to-min(1000px, {
+    width: 70%;
+  });
+  .respond-to-min(1100px, {
+    width: 71%;
+  });
 }
 
 .input-with-btns_input input {
@@ -86,6 +95,15 @@
   });
   .respond-to-min(801px, {
     width: 60%;
+  });
+  .respond-to-min(960px, {
+    width: 68%;
+  });
+  .respond-to-min(1000px, {
+    width: 70%;
+  });
+  .respond-to-min(1100px, {
+    width: 71%;
   });
 }
 

--- a/src/static/css/module/prepare-worksheets.less
+++ b/src/static/css/module/prepare-worksheets.less
@@ -22,24 +22,45 @@
 @btn-delete-hover-color: @gray-20;
 
 // Inputs with buttons for goals, risks, and red flags.
-.input-with-btns_btns {
-  float: right;
+
+.input-with-btns {
+  display: block;
+  clear: both;
+  margin-bottom: 10px;
 }
 
 .input-with-btns_input {
   display: block;
   overflow: hidden;
+  margin-bottom: 20px;
   padding-right: 10px;
+  .respond-to-min(750px, {
+    margin-bottom: 10px;
+    float: left;
+    width: 68%;
+  });
+  .respond-to-min(801px, {
+    width: 60%;
+  });
 }
 
 .input-with-btns_input input {
   width: 100%;
 }
 
-.input-with-btns {
-  display: block;
-  clear: both;
-  margin-bottom: 10px;
+.input-with-btns_btns {
+  // Set the width of the right column so it doesn't re-size
+  // as the button webfont text and icons load.
+  .respond-to-min(750px, {
+    width: @right-col-width;
+    float: right;
+  });
+  label h6 {
+    // display: inline-block;
+    .respond-to-min(750px, {
+      .u-visually-hidden();
+    });
+  }
 }
 
 // Preparation worksheets goals, risks, red flag icon colors.
@@ -58,19 +79,27 @@
 // Inputs with buttons for goals, risks, and red flags.
 // The color settings override CF colors.
 
+.worksheet-left-col-header {
+  float: left;
+  .respond-to-min(750px, {
+    width: 68%;
+  });
+  .respond-to-min(801px, {
+    width: 60%;
+  });
+}
+
 // Right-hand column of the worksheets (priority, likely-ness, etc).
 .worksheet-right-col-header {
-  .u-right();
-  width: @right-col-width;
+  display: none;
+  .respond-to-min(750px, {
+    display: block;
+    .u-right();
+    width: @right-col-width;
+  });
 }
 
 // Individual graded input settings.
-
-.input-with-btns_btns {
-  // Set the width of the right column so it doesn't re-size
-  // as the button webfont text and icons load.
-  width: @right-col-width;
-}
 
 .input-graded .content_bar {
   border-top: 1px solid @gray-50;

--- a/src/static/css/module/prepare-worksheets.less
+++ b/src/static/css/module/prepare-worksheets.less
@@ -8,18 +8,44 @@
 @right-col-width: 202px;
 
 // Colors
-@btn-grade-disabled-color: @gray-80;
-@btn-grade-unselected-color: @gray-50;
-@btn-grade-selected-color: @darkgray;
-@btn-grade-hover-color: @gray;
+@btn-grade-disabled-color: @gray-20;
+@btn-grade-unselected-color: @gray-20;
+@btn-grade-selected-color: @green-midtone;
+@btn-grade-hover-color: @green-tint;
 
-@btn-grade-disabled-text-color: @white;
+@btn-grade-disabled-text-color: @darkgray;
 @btn-grade-unselected-text-color: @darkgray;
-@btn-grade-selected-text-color: @white;
-@btn-grade-hover-text-color: @white;
+@btn-grade-selected-text-color: @black;
+@btn-grade-hover-text-color: @black;
 
-@btn-delete-color: @gray;
-@btn-delete-hover-color: @gray-20;
+@btn-delete-color: @pacific;
+@btn-delete-hover-color: @pacific-80;
+
+@btn-secondary-color: @gray;
+@btn-secondary-hover-color: @gray-80;
+
+@super-btn-font-size:           18px;
+
+.btn-secondary {
+  background-color: @btn-secondary-color;
+  &:hover,
+  &:focus {
+    background-color: @btn-secondary-hover-color;
+  }
+}
+
+.btn__super {
+
+    padding:
+        unit( 11px / @super-btn-font-size, em )
+        unit( 29px / @super-btn-font-size, em );
+    font-size: unit( @super-btn-font-size / @base-font-size-px, em );
+
+    & + & {
+        margin-left: unit( 6px / @super-btn-font-size, em);
+    }
+
+}
 
 // Inputs with buttons for goals, risks, and red flags.
 
@@ -40,10 +66,14 @@
     width: 68%;
   });
   .respond-to-min(801px, {
-    width: 60%;
+    margin-bottom: 20px;
+    width: auto;
+    float: none;    
   });
   .respond-to-min(960px, {
+    margin-bottom: 10px;
     width: 68%;
+    float: left;
   });
   .respond-to-min(1000px, {
     width: 70%;
@@ -64,9 +94,19 @@
     width: @right-col-width;
     float: right;
   });
+  .respond-to-min(801px, {
+    width: auto;
+    float: none;
+  });
+  .respond-to-min(960px, {
+    width: @right-col-width;
+    float: right;
+  });
   label h6 {
-    // display: inline-block;
-    .respond-to-min(750px, {
+    .respond-to-range(750px, 801px, {
+      .u-visually-hidden();
+    });
+    .respond-to-min(960px, {
       .u-visually-hidden();
     });
   }
@@ -111,6 +151,9 @@
 .worksheet-right-col-header {
   display: none;
   .respond-to-min(750px, {
+    display: none;
+  });
+  .respond-to-min(960px, {
     display: block;
     .u-right();
     width: @right-col-width;

--- a/src/static/js/templates/prepare-worksheets/input-graded.hbs
+++ b/src/static/js/templates/prepare-worksheets/input-graded.hbs
@@ -4,12 +4,7 @@
       <div class="input-with-btns_input">
         <input type="text" value="{{input.text}}" placeholder="{{placeholder}}">
       </div>
-      {{#if input.explanation}}
-      <div class="input-explanation block__sub">
-        <p>{{{input.explanation}}}</p>
-      </div>
-      {{/if}}
-      
+
       <div class="input-with-btns_btns">
         <label><h6>Priority level: choose one</h6>
           <button class="btn btn__grouped-first {{#if is_0}}active{{/if}}">{{grades.[0]}}</button>
@@ -20,6 +15,12 @@
           {{/if}}
         </label>
       </div>
+
+      {{#if input.explanation}}
+      <div class="input-explanation block__sub">
+        <p>{{{input.explanation}}}</p>
+      </div>
+      {{/if}}
       
     </section>
   </div>

--- a/src/static/js/templates/prepare-worksheets/input-graded.hbs
+++ b/src/static/js/templates/prepare-worksheets/input-graded.hbs
@@ -1,8 +1,11 @@
 <section class="input-graded block__border-bottom u-mb20">
-  <div class="u-mt20 u-mb20">
+  <div class="u-mt20 u-mb20 u-clearfix">
     <section class="input-with-btns">
+      <div class="input-with-btns_input">
+        <input type="text" value="{{input.text}}" placeholder="{{placeholder}}">
+      </div>
       <div class="input-with-btns_btns">
-        <label><span class="u-visually-hidden">Priority level: choose one</span>
+        <label><h6>Priority level: choose one</h6>
           <button class="btn btn__grouped-first {{#if is_0}}active{{/if}}">{{grades.[0]}}</button>
           <button class="btn btn__grouped {{#if is_1}}active{{/if}}">{{grades.[1]}}</button>
           <button class="btn btn__grouped-last {{#if is_2}}active{{/if}}">{{grades.[2]}}</button>
@@ -10,9 +13,6 @@
           <span class="btn-input-delete cf-form_input-icon cf-icon cf-icon-delete-round" role="button" title="Delete"></span>
           {{/if}}
         </label>
-      </div>
-      <div class="input-with-btns_input">
-        <input type="text" value="{{input.text}}" placeholder="{{placeholder}}">
       </div>
     </section>
   </div>

--- a/src/static/js/templates/prepare-worksheets/worksheet-editor.hbs
+++ b/src/static/js/templates/prepare-worksheets/worksheet-editor.hbs
@@ -1,7 +1,7 @@
 <article>
-   <header class="subheading">
+   <header class="subheading u-clearfix">
+     <h4 class="worksheet-left-col-header" ] aria-hidden="true">{{title}}</h4>
      <h4 class="worksheet-right-col-header" aria-hidden="true">{{prompt}}</h4>
-     <h4 aria-hidden="true">{{title}}</h4>
    </header>
 
    <div class="worksheet-input-group">

--- a/src/static/js/templates/prepare-worksheets/worksheet-editor.hbs
+++ b/src/static/js/templates/prepare-worksheets/worksheet-editor.hbs
@@ -10,6 +10,6 @@
 
    {{#if is_graded}}
        <button class="btn btn-worksheet-add-row">Add an item</button>
-       <button class="btn btn-worksheet-reset">Reset list</button>
+       <button class="btn btn-worksheet-reset btn-secondary">Reset list</button>
    {{/if}}
 </article>


### PR DESCRIPTION
## Additions
* Styles for btn__super and btn__secondary to match latest design
* Updated button colors for the priority buttons
* Stacked buttons + inputs for smaller screens < 600px wide, plus stacked design between 800-960px widths so that inputs are always legible.
* Stacked priority labeling above the priority buttons for the same breakpoints described above

## Screenshots
#### Small screen ~320px width styles
![screen shot 2015-02-23 at 11 28 10 am](https://cloud.githubusercontent.com/assets/702526/6333880/c079cd2a-bb5e-11e4-9200-ef3ef246546d.png)

#### Medium screen ~600px - unstacked
![screen shot 2015-02-23 at 11 29 16 am](https://cloud.githubusercontent.com/assets/702526/6333895/e2f4ea4c-bb5e-11e4-81ee-ed9e35752ea1.png)

#### Mediumer screen ~800px - re-stacked
![screen shot 2015-02-23 at 11 29 38 am](https://cloud.githubusercontent.com/assets/702526/6333918/08ae29f6-bb5f-11e4-8b0d-1e11740c6737.png)

#### Large screen 920px+ - unstacked again.
![screen shot 2015-02-23 at 11 31 17 am](https://cloud.githubusercontent.com/assets/702526/6333922/11dff19e-bb5f-11e4-99a6-b1c2a1196c6e.png)

#### Large screen with updated button styles.
![screen shot 2015-02-23 at 1 18 46 pm](https://cloud.githubusercontent.com/assets/702526/6333928/1f90834e-bb5f-11e4-9c80-796f452587c1.png)
