### PR TITLE
remove expandables markup and add 'your alternative' text to summary goals alternatives

### DIFF
--- a/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
+++ b/src/static/js/templates/prepare-worksheets/page-summary-section.hbs
@@ -9,19 +9,7 @@
                   <h4>{{text}}</h4>
                 
                 {{#if altText}}
-                  <div class="expandable">
-                    <a href="#" class="short-desc expandable_target">
-                        <span class="expandable_cue-open">
-                            <span class="cf-icon cf-icon-plus-round"></span>&nbsp;See your alternative
-                        </span>
-                        <span class="expandable_cue-close">
-                            <span class="cf-icon cf-icon-minus-round"></span>&nbsp;Hide your alternative
-                        </span>
-                    </a>
-                    <div class="expandable_content">
-                        <p class="short-desc block__sub block__flush-bottom">{{altText}}</p>
-                    </div>
-                  </div>
+                    <p class="short-desc block__sub block__flush-bottom"><strong>Your alternative: </strong>{{altText}}</p>
                 {{/if}}
 
                 </div>


### PR DESCRIPTION
## Added
* "Your alternative" bolded text before each alternative on the summary page goals.

## Removed
* Expandables markup, because Chris removed expandables JS as part of #358 and they're not necessary for our MVP and they were breakin stuff

## Screenshot
![screen shot 2015-02-26 at 12 03 29 pm](https://cloud.githubusercontent.com/assets/702526/6397026/0ecb1792-bdb0-11e4-95a4-7852613775c8.png)
