### PR TITLE
working sourcemaps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,6 @@ module.exports = function(grunt) {
      * LESS: https://github.com/gruntjs/grunt-contrib-less
      *
      * Compile LESS files to CSS.
-     * Source maps are slow, so they're separated into their own task for when needed
      */
     less: {
       watch: {
@@ -77,8 +76,11 @@ module.exports = function(grunt) {
       map: {
         options: {
           paths: grunt.file.expand('src/static/vendor/**/'),
+          compress: false,
           sourceMap: true,
-          sourceMapRootpath: '/'
+          sourceMapFilename: './dist/static/css/main.css.map',
+          sourceMapBasepath: './src/static/css/',
+          sourceMapURL: 'main.css.map'
         },
         files: {
           './dist/static/css/main.css': ['./src/static/css/main.less']
@@ -408,7 +410,7 @@ module.exports = function(grunt) {
           interrupt: true,
         },
         files: ['Gruntfile.js', 'src/static/css/*.less', 'src/static/css/module/*.less', 'src/static/js/templates/**/*.hbs'],
-        tasks: ['css', 'cssmin']
+        tasks: ['css']
       },
       all: {
         options: {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-contrib-copy": "latest",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-less": "~0.11.0",
+    "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.4.4",
     "grunt-mocha-istanbul": "^2.3.1",

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -4,16 +4,16 @@
    ========================================================================== */
 
 // import Normalize before all other LESS/CSS
-@import (less) "../../vendor/normalize-css/normalize.css";
+@import "../../vendor/normalize-css/normalize.css";
 
 // import combined CF component LESS
 @import "../../vendor/cf-concat/cf.less";
 
 // Import the brand color palette.
-@import (less) "brand-palette.less";
+@import "brand-palette.less";
 
 // Override the Capital Framework theme variables with colors from the brand color palette.
-@import (less) "cf-theme-overrides.less";
+@import "cf-theme-overrides.less";
 
 // import CFPB nemo theme header and footer styles
 .nemo {


### PR DESCRIPTION
Running `grunt less:map` will now produce a working sourcemap so that you can dig into the CSS more easily from dev tools. It's not in the watch task as it is super slow (around 7 seconds - so many files!). 

The gruntfile could use some love in general. I'm happy to help with that.

Also, HI OAH!!!
![selfie-0](http://i.imgur.com/vo137LM.gif)
