### PR TITLE
Fixing a dependency issue for this branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "keywords": [],
   "dependencies": {
     "amortize": "0.2.2",
+    "debounce": "0.0.3",
     "date-format": "0.0.2",
     "foreach": "2.0.4",
     "format-usd": "^0.2.0",


### PR DESCRIPTION
Current prod build is failing with this error: 
```
Running "browserify:build" (browserify) task
>> Error: Cannot find module 'debounce' from '/var/lib/jenkins/workspace/OaH-prod-frontend-build/src/static/js/modules'
```

Adding in this dependency to fix it.  