### PR TITLE
use earlier version of acorn-globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "acorn-globals": "0.12.0",
+    "acorn-globals": "1.0.1",
     "amortize": "0.2.2",
     "debounce": "0.0.3",
     "date-format": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "acorn-globals": "1.0.0",
+    "acorn-globals": "0.12.0",
     "amortize": "0.2.2",
     "debounce": "0.0.3",
     "date-format": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "acorn-globals": "1.0.0",
     "amortize": "0.2.2",
     "debounce": "0.0.3",
     "date-format": "0.0.2",


### PR DESCRIPTION
Attempting to use earlier version of acorn to fix https://github.com/marijnh/acorn/issues/232