### PR TITLE
Shrinkwrap node deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,20 +100,24 @@ If you run into problems or have any questions about Sheer, check out [Sheer on 
 	```
 	$ npm install -g grunt-cli bower browserify
 	```
+
 3. Navigate to the cloned `owning-a-home` directory and install the project's node dependencies:
 	```
 	$ npm install
 	```
+
 4. Navigate to the `config` folder. In that folder, copy the `example-config.json` file and rename it `config.json`. This can be done from the command line with the following two commands:
 	```
 	$ cd config
 	$ cp example-config.json config.json
 	```
+
 5. Run grunt to build the site:
 	```
 	$ grunt
 	```
 
+[npm-shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) is used to lock down dependencies. If you add any dependencies to package.json, re-run `npm shrinkwrap` to generate a new `npm-shrinkwrap.json` file.
 
 ## Configuration
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,661 @@
+{
+  "name": "owning-a-home",
+  "version": "0.0.1",
+  "dependencies": {
+    "amortize": {
+      "version": "0.2.2",
+      "from": "amortize@0.2.2",
+      "resolved": "http://registry.npmjs.org/amortize/-/amortize-0.2.2.tgz"
+    },
+    "date-format": {
+      "version": "0.0.2",
+      "from": "date-format@0.0.2",
+      "resolved": "http://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz"
+    },
+    "debounce": {
+      "version": "0.0.3",
+      "from": "debounce@0.0.3",
+      "resolved": "http://registry.npmjs.org/debounce/-/debounce-0.0.3.tgz"
+    },
+    "foreach": {
+      "version": "2.0.4",
+      "from": "foreach@2.0.4",
+      "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.4.tgz"
+    },
+    "format-usd": {
+      "version": "0.2.0",
+      "from": "format-usd@^0.2.0"
+    },
+    "fuzzy-state-search": {
+      "version": "0.1.0",
+      "from": "fuzzy-state-search@0.1.0",
+      "resolved": "http://registry.npmjs.org/fuzzy-state-search/-/fuzzy-state-search-0.1.0.tgz"
+    },
+    "handlebars": {
+      "version": "1.3.0",
+      "from": "handlebars@1.3.0",
+      "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@~0.3",
+          "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2",
+              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@~2.3",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.6",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@~0.1.7",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "hbsfy": {
+      "version": "1.3.2",
+      "from": "hbsfy@1.3.2",
+      "resolved": "http://registry.npmjs.org/hbsfy/-/hbsfy-1.3.2.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.6",
+          "from": "through@~2.3.4",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.3.6.tgz"
+        }
+      }
+    },
+    "is-money-usd": {
+      "version": "0.1.2",
+      "from": "is-money-usd@0.1.2",
+      "resolved": "http://registry.npmjs.org/is-money-usd/-/is-money-usd-0.1.2.tgz"
+    },
+    "jquery": {
+      "version": "1.11.0",
+      "from": "jquery@1.11.0",
+      "resolved": "http://registry.npmjs.org/jquery/-/jquery-1.11.0.tgz"
+    },
+    "jquery.scrollto": {
+      "version": "1.4.14",
+      "from": "jquery.scrollto@1.4.14",
+      "resolved": "http://registry.npmjs.org/jquery.scrollto/-/jquery.scrollto-1.4.14.tgz"
+    },
+    "jsdom": {
+      "version": "4.1.0",
+      "from": "jsdom@*",
+      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-4.1.0.tgz",
+      "dependencies": {
+        "browser-request": {
+          "version": "0.3.3",
+          "from": "browser-request@>= 0.3.1 < 0.4.0",
+          "resolved": "http://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
+        },
+        "cssom": {
+          "version": "0.3.0",
+          "from": "cssom@>= 0.3.0 < 0.4.0",
+          "resolved": "http://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+        },
+        "cssstyle": {
+          "version": "0.2.23",
+          "from": "cssstyle@>= 0.2.23 < 0.3.0",
+          "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.23.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.2",
+          "from": "htmlparser2@>= 3.7.3 < 4.0.0",
+          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@2.3",
+              "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@1.5",
+              "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@0",
+                  "resolved": "http://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@~1.1.1",
+                      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@~1.1.1",
+                      "resolved": "http://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@1",
+              "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@1.1",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@1.0",
+              "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "nwmatcher": {
+          "version": "1.3.4",
+          "from": "nwmatcher@>= 1.3.4 < 2.0.0",
+          "resolved": "http://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz"
+        },
+        "parse5": {
+          "version": "1.4.1",
+          "from": "parse5@>= 1.3.2 < 2.0.0",
+          "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.4.1.tgz"
+        },
+        "request": {
+          "version": "2.54.0",
+          "from": "request@>= 2.44.0 < 3.0.0",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.54.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@~0.9.0",
+              "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "caseless@~0.9.0",
+              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.0",
+              "from": "forever-agent@~0.6.0",
+              "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.0.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "form-data@~0.2.0",
+              "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@~0.9.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@~5.0.0",
+              "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.10",
+              "from": "mime-types@~2.0.1",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.8.0",
+                  "from": "mime-db@~1.8.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@~1.4.0",
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.4.1",
+              "from": "qs@~2.4.0",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@~0.4.0",
+              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@~0.10.0",
+              "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@^0.1.5",
+                  "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "oauth-sign@~0.6.0",
+              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "hawk@~2.3.0",
+              "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.12.0",
+                  "from": "hoek@2.x.x",
+                  "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+                },
+                "boom": {
+                  "version": "2.7.0",
+                  "from": "boom@2.x.x",
+                  "resolved": "http://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "cryptiles@2.x.x",
+                  "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.x.x",
+                  "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@~0.5.0",
+              "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@~0.0.4",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@~0.0.5",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@~0.1.1",
+              "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "har-validator": {
+              "version": "1.6.1",
+              "from": "har-validator@^1.4.0",
+              "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.9.24",
+                  "from": "bluebird@^2.9.21",
+                  "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+                },
+                "chalk": {
+                  "version": "1.0.0",
+                  "from": "chalk@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.0.1",
+                      "from": "ansi-styles@^2.0.1",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "1.0.3",
+                      "from": "has-ansi@^1.0.3",
+                      "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@^1.1.0",
+                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@^4.0.1",
+                          "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@^2.0.1",
+                      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@^1.1.0",
+                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "1.3.1",
+                      "from": "supports-color@^1.3.0",
+                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.7.1",
+                  "from": "commander@^2.7.1",
+                  "resolved": "http://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.10.0",
+                  "from": "is-my-json-valid@^2.10.0",
+                  "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.1.1",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "1.1.0",
+                      "from": "jsonpointer@^1.1.0",
+                      "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "from": "xml-name-validator@>= 2.0.1 < 3.0.0",
+          "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+        },
+        "xmlhttprequest": {
+          "version": "1.7.0",
+          "from": "xmlhttprequest@>= 1.6.0 < 2.0.0",
+          "resolved": "http://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
+        },
+        "acorn-globals": {
+          "version": "1.0.2",
+          "from": "acorn-globals@1.0.2",
+          "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.11.0",
+              "from": "acorn@0.11.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+            }
+          }
+        },
+        "acorn": {
+          "version": "0.11.0",
+          "from": "acorn@0.11.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+        },
+        "escodegen": {
+          "version": "1.6.1",
+          "from": "escodegen@^1.6.1",
+          "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "estraverse@^1.9.1",
+              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            },
+            "esutils": {
+              "version": "1.1.6",
+              "from": "esutils@^1.1.6",
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@^1.2.2",
+              "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "optionator@^0.5.0",
+              "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.1",
+                  "from": "prelude-ls@~1.1.1",
+                  "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@~0.1.2",
+                  "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "type-check@~0.3.1",
+                  "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@~0.2.5",
+                  "resolved": "http://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.6",
+                  "from": "fast-levenshtein@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@~0.1.40",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jumbo-mortgage": {
+      "version": "0.3.3",
+      "from": "jumbo-mortgage@0.3.3",
+      "resolved": "http://registry.npmjs.org/jumbo-mortgage/-/jumbo-mortgage-0.3.3.tgz",
+      "dependencies": {
+        "format-usd": {
+          "version": "0.1.0",
+          "from": "format-usd@~0.1.0",
+          "resolved": "http://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz"
+        }
+      }
+    },
+    "loan-calc": {
+      "version": "0.2.1",
+      "from": "loan-calc@0.2.1",
+      "resolved": "http://registry.npmjs.org/loan-calc/-/loan-calc-0.2.1.tgz"
+    },
+    "median": {
+      "version": "0.0.2",
+      "from": "median@0.0.2",
+      "resolved": "http://registry.npmjs.org/median/-/median-0.0.2.tgz"
+    },
+    "objectified": {
+      "version": "0.4.5",
+      "from": "objectified@0.4.5",
+      "resolved": "http://registry.npmjs.org/objectified/-/objectified-0.4.5.tgz",
+      "dependencies": {
+        "debounce": {
+          "version": "1.0.0",
+          "from": "debounce@~1.0.0",
+          "resolved": "http://registry.npmjs.org/debounce/-/debounce-1.0.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "1.0.1",
+              "from": "date-now@1.0.1",
+              "resolved": "http://registry.npmjs.org/date-now/-/date-now-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "overall-loan-cost": {
+      "version": "0.3.4",
+      "from": "overall-loan-cost@0.3.4",
+      "resolved": "http://registry.npmjs.org/overall-loan-cost/-/overall-loan-cost-0.3.4.tgz"
+    },
+    "stay-positive": {
+      "version": "0.3.0",
+      "from": "stay-positive@0.3.0",
+      "resolved": "http://registry.npmjs.org/stay-positive/-/stay-positive-0.3.0.tgz"
+    },
+    "unformat-usd": {
+      "version": "0.1.1",
+      "from": "unformat-usd@0.1.1",
+      "resolved": "http://registry.npmjs.org/unformat-usd/-/unformat-usd-0.1.1.tgz"
+    }
+  }
+}


### PR DESCRIPTION
This locks down all node dependencies so that we know exactly what is being installed and can circumvent the Travis/acorn bug.

See: https://docs.npmjs.com/cli/shrinkwrap