### PR TITLE
Update dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,7 +24,7 @@
     },
     "format-usd": {
       "version": "0.2.0",
-      "from": "format-usd@^0.2.0"
+      "from": "format-usd@>=0.2.0 <0.3.0"
     },
     "fuzzy-state-search": {
       "version": "0.1.0",
@@ -38,29 +38,29 @@
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@~0.3",
+          "from": "optimist@>=0.3.0 <0.4.0",
           "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@0.0.2",
               "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@~2.3",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
           "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@~0.1.7",
+              "from": "source-map@>=0.1.7 <0.2.0",
               "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
@@ -80,9 +80,9 @@
       "resolved": "http://registry.npmjs.org/hbsfy/-/hbsfy-1.3.2.tgz",
       "dependencies": {
         "through": {
-          "version": "2.3.6",
-          "from": "through@~2.3.4",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.3.6.tgz"
+          "version": "2.3.7",
+          "from": "through@>=2.3.4 <2.4.0",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.3.7.tgz"
         }
       }
     },
@@ -102,53 +102,53 @@
       "resolved": "http://registry.npmjs.org/jquery.scrollto/-/jquery.scrollto-1.4.14.tgz"
     },
     "jsdom": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "from": "jsdom@*",
-      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-4.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-4.2.0.tgz",
       "dependencies": {
         "browser-request": {
           "version": "0.3.3",
-          "from": "browser-request@>= 0.3.1 < 0.4.0",
+          "from": "browser-request@>=0.3.1 <0.4.0",
           "resolved": "http://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
         },
         "cssom": {
           "version": "0.3.0",
-          "from": "cssom@>= 0.3.0 < 0.4.0",
+          "from": "cssom@>=0.3.0 <0.4.0",
           "resolved": "http://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
         },
         "cssstyle": {
           "version": "0.2.23",
-          "from": "cssstyle@>= 0.2.23 < 0.3.0",
+          "from": "cssstyle@>=0.2.23 <0.3.0",
           "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.23.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@>= 3.7.3 < 4.0.0",
+          "from": "htmlparser2@>=3.7.3 <4.0.0",
           "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@1.5",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "http://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@~1.1.1",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
                       "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@~1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "http://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -157,17 +157,17 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@1",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -177,51 +177,51 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "nwmatcher": {
           "version": "1.3.4",
-          "from": "nwmatcher@>= 1.3.4 < 2.0.0",
+          "from": "nwmatcher@>=1.3.4 <2.0.0",
           "resolved": "http://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz"
         },
         "parse5": {
-          "version": "1.4.1",
-          "from": "parse5@>= 1.3.2 < 2.0.0",
-          "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.4.1.tgz"
+          "version": "1.4.2",
+          "from": "parse5@>=1.3.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.4.2.tgz"
         },
         "request": {
-          "version": "2.54.0",
-          "from": "request@>= 2.44.0 < 3.0.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.54.0.tgz",
+          "version": "2.55.0",
+          "from": "request@>=2.44.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@~0.9.0",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -231,12 +231,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -245,56 +245,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@~0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
               "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
-              "version": "0.6.0",
-              "from": "forever-agent@~0.6.0",
-              "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.0.tgz"
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@~0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.10",
-              "from": "mime-types@~2.0.1",
+              "from": "mime-types@>=2.0.1 <2.1.0",
               "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.8.0",
-                  "from": "mime-db@~1.8.0",
+                  "from": "mime-db@>=1.8.0 <1.9.0",
                   "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "2.4.1",
-              "from": "qs@~2.4.0",
+              "from": "qs@>=2.4.0 <2.5.0",
               "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -311,12 +311,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -333,49 +333,49 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@~0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
               "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@~2.3.0",
+              "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.12.0",
-                  "from": "hoek@2.x.x",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
                 },
                 "boom": {
                   "version": "2.7.0",
-                  "from": "boom@2.x.x",
+                  "from": "boom@>=2.0.0 <3.0.0",
                   "resolved": "http://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@1.x.x",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -387,112 +387,112 @@
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@~0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.6.1",
-              "from": "har-validator@^1.4.0",
+              "from": "har-validator@>=1.4.0 <2.0.0",
               "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.24",
-                  "from": "bluebird@^2.9.21",
+                  "from": "bluebird@>=2.9.21 <3.0.0",
                   "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
                 },
                 "chalk": {
                   "version": "1.0.0",
-                  "from": "chalk@^1.0.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
                   "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.0.1",
-                      "from": "ansi-styles@^2.0.1",
+                      "from": "ansi-styles@>=2.0.1 <3.0.0",
                       "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@^1.0.2",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                       "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "1.0.3",
-                      "from": "has-ansi@^1.0.3",
+                      "from": "has-ansi@>=1.0.3 <2.0.0",
                       "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@^1.1.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         },
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@^4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
                           "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@^2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@^1.1.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "1.3.1",
-                      "from": "supports-color@^1.3.0",
+                      "from": "supports-color@>=1.3.0 <2.0.0",
                       "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.7.1",
-                  "from": "commander@^2.7.1",
+                  "from": "commander@>=2.7.1 <3.0.0",
                   "resolved": "http://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.10.0",
-                  "from": "is-my-json-valid@^2.10.0",
+                  "from": "is-my-json-valid@>=2.10.0 <3.0.0",
                   "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.1.1",
-                      "from": "generate-object-property@^1.1.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@^1.0.0",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@^1.1.0",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                       "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@^4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -503,91 +503,91 @@
         },
         "xml-name-validator": {
           "version": "2.0.1",
-          "from": "xml-name-validator@>= 2.0.1 < 3.0.0",
+          "from": "xml-name-validator@>=2.0.1 <3.0.0",
           "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
         },
         "xmlhttprequest": {
           "version": "1.7.0",
-          "from": "xmlhttprequest@>= 1.6.0 < 2.0.0",
+          "from": "xmlhttprequest@>=1.6.0 <2.0.0",
           "resolved": "http://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
         },
         "acorn-globals": {
-          "version": "1.0.2",
-          "from": "acorn-globals@1.0.2",
-          "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
+          "version": "1.0.4",
+          "from": "acorn-globals@>=1.0.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.11.0",
-              "from": "acorn@0.11.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+              "version": "1.0.3",
+              "from": "acorn@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-1.0.3.tgz"
             }
           }
         },
         "acorn": {
-          "version": "0.11.0",
-          "from": "acorn@0.11.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+          "version": "0.12.0",
+          "from": "acorn@>=0.12.0 <0.13.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.12.0.tgz"
         },
         "escodegen": {
           "version": "1.6.1",
-          "from": "escodegen@^1.6.1",
+          "from": "escodegen@>=1.6.1 <2.0.0",
           "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
           "dependencies": {
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@^1.9.1",
+              "from": "estraverse@>=1.9.1 <2.0.0",
               "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@^1.1.6",
+              "from": "esutils@>=1.1.6 <2.0.0",
               "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@^1.2.2",
+              "from": "esprima@>=1.2.2 <2.0.0",
               "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@^0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
               "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.1",
-                  "from": "prelude-ls@~1.1.1",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
                   "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@~0.1.2",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
                   "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "type-check@~0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0",
                   "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@~0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
                   "resolved": "http://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.6",
-                  "from": "fast-levenshtein@~1.0.0",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                   "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@~0.1.40",
+              "from": "source-map@>=0.1.40 <0.2.0",
               "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
@@ -608,7 +608,7 @@
       "dependencies": {
         "format-usd": {
           "version": "0.1.0",
-          "from": "format-usd@~0.1.0",
+          "from": "format-usd@>=0.1.0 <0.2.0",
           "resolved": "http://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz"
         }
       }
@@ -630,7 +630,7 @@
       "dependencies": {
         "debounce": {
           "version": "1.0.0",
-          "from": "debounce@~1.0.0",
+          "from": "debounce@>=1.0.0 <1.1.0",
           "resolved": "http://registry.npmjs.org/debounce/-/debounce-1.0.0.tgz",
           "dependencies": {
             "date-now": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-autoprefixer": "~0.6.5",
     "grunt-banner": "latest",
     "grunt-bower-task": "~0.4.0",
-    "grunt-browserify": "~3.0.1",
+    "grunt-browserify": "^3.6.0",
     "grunt-combine-media-queries": "~1.0.2",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "latest",


### PR DESCRIPTION
The acorn browserify bugs (OAH-notes#896) were fixed by its maintainer so here's a new shrinkwrap file that uses the newer version of acorn. Plus grunt-browserify was really old so I updated it.