### PR TITLE
Landing page journey link tests

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,10 +43,10 @@
 
               <div class="phase_intro content-l_col content-l_col-1-2">
                 <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                <h3 class="u-mb15"><a href="{{ base_url }}process/prepare" class="heading_link">Prepare to shop</a></h3>
+                <h3 class="u-mb15"><a href="{{ base_url }}process/prepare" class="heading_link" id="prepare-header-link">Prepare to shop</a></h3>
                 <p>Not sure how to get started, how much you can afford, or what to expect when buying a home? Set yourself up for success with a little bit of preparation.</p>
                 <p>
-                  <a class="icon-link icon-link__right" href="{{ base_url }}process/prepare">
+                  <a class="icon-link icon-link__right" href="{{ base_url }}process/prepare" id="prepare-learn-link">
                     <span class="icon-link_text">Learn more</span>
                   </a>
                 </p>
@@ -74,10 +74,10 @@
 
               <div class="phase_intro content-l_col content-l_col-1-2">
                 <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                <h3 class="u-mb15"><a href="{{ base_url }}process/explore" class="heading_link">Explore loan options</a></h3>
+                <h3 class="u-mb15"><a href="{{ base_url }}process/explore" class="heading_link" id="explore-header-link">Explore loan options</a></h3>
                 <p>You've got a pretty good idea of your priorities and budget, and you're ready to start home shopping in earnest. Now is the time to start exploring loan options and meeting with lenders.</p>
                 <p>
-                  <a class="icon-link icon-link__right" href="{{ base_url }}process/explore">
+                  <a class="icon-link icon-link__right" href="{{ base_url }}process/explore" id="explore-learn-link">
                     <span class="icon-link_text">Learn more</span>
                   </a>
                 </p>
@@ -106,10 +106,10 @@
 
               <div class="phase_intro content-l_col content-l_col-1-2">
                 <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                <h3 class="u-mb15"><a href="{{ base_url }}process/compare" class="heading_link">Compare loan packages</a></h3>
+                <h3 class="u-mb15"><a href="{{ base_url }}process/compare" class="heading_link" id="compare-header-link">Compare loan packages</a></h3>
                 <p>You've made an offer on a home. Congratulations! Now is the time to get official loan offers from lenders, compare your options, and negotiate.</p>
                 <p>
-                  <a class="icon-link icon-link__right" href="{{ base_url }}process/compare">
+                  <a class="icon-link icon-link__right" href="{{ base_url }}process/compare" id="compare-learn-link">
                     <span class="icon-link_text">Learn more</span>
                   </a>
                 </p>
@@ -136,10 +136,10 @@
 
                 <div class="phase_intro content-l_col content-l_col-1-2">
                   <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                  <h3 class="u-mb15"><a href="{{ base_url }}process/decide" class="heading_link">Decide and close</a></h3>
+                  <h3 class="u-mb15"><a href="{{ base_url }}process/decide" class="heading_link" id="decide-header-link">Decide and close</a></h3>
                   <p>You're ready to choose a specific loan package and move forwards to closing. There will be lots of paperwork to submit and things to keep track of. We lay it out for you step by step.</p>
                   <p>
-                    <a class="icon-link icon-link__right" href="{{ base_url }}process/decide">
+                    <a class="icon-link icon-link__right" href="{{ base_url }}process/decide" id="decide-learn-link">
                       <span class="icon-link_text">Learn more</span>
                     </a>
                   </p>
@@ -167,10 +167,10 @@
 
               <div class="phase_intro content-l_col content-l_col-1-2">
                 <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                <h3 class="u-mb15"><a href="{{ base_url }}process/maintain" class="heading_link">Maintain your mortgage</a></h3>
+                <h3 class="u-mb15"><a href="{{ base_url }}process/maintain" class="heading_link" id="maintain-header-link">Maintain your mortgage</a></h3>
                 <p>Congratulations! You've closed on your new home. Get tips for how to manage your mortgage to your advantage, and what to do if you're struggling to make your payments.</p>
                 <p>
-                  <a class="icon-link icon-link__right" href="{{ base_url }}process/maintain">
+                  <a class="icon-link icon-link__right" href="{{ base_url }}process/maintain" id="maintain-learn-link">
                     <span class="icon-link_text">Learn more</span>
                   </a>
                 </p>

--- a/test/browser_testing/features/navigation.feature
+++ b/test/browser_testing/features/navigation.feature
@@ -4,19 +4,24 @@ Feature: verify the navigation tabs/links works according to requirements
   So that I can easily navigate the site
 
 @smoke_testing @landing_page
-Scenario Outline: Test Learn more links in the landing page
+Scenario Outline: Test Journey links in the landing page
   Given I navigate to the OAH Landing page
-  When I click on the Learn more link inside "<section_name>"
+  When I click on the link with id "<link_id>"
   Then I should be directed to the internal "<relative_url>" URL
   And I should see "<page_title>" displayed in the page title
 
 Examples:
-  | section_name      		                    | page_title                      | relative_url                             |
-  | Prepare to shop         | Know the Process                    | process/prepare/                            |
-  | Explore loan options         | Know the Process                    | process/explore/                            |
-  | Compare loan packages        | Know the Process                    | process/compare/                            |
-  | Decide and close         | Know the Process                    | process/decide/                            |
-  | Maintain your mortgage         | Know the Process                    | process/maintain/                            |
+  | link_id   		                    | page_title                      | relative_url                             |
+  | prepare-header-link         | Know the Process                    | process/prepare/                            |
+  | prepare-learn-link         | Know the Process                    | process/prepare/                            |
+  | explore-header-link         | Know the Process                    | process/explore/                            |
+  | explore-learn-link         | Know the Process                    | process/explore/                            |
+  | compare-header-link         | Know the Process                    | process/compare/                            |
+  | compare-learn-link         | Know the Process                    | process/compare/                            |
+  | decide-header-link         | Know the Process                    | process/decide/                            |
+  | decide-learn-link         | Know the Process                    | process/decide/                            |
+  | maintain-header-link         | Know the Process                    | process/maintain/                            |
+  | maintain-learn-link         | Know the Process                    | process/maintain/                            |
 
 
 @smoke_testing @landing_page

--- a/test/browser_testing/features/pages/navigation.py
+++ b/test/browser_testing/features/pages/navigation.py
@@ -40,9 +40,8 @@ class Navigation(Base):
                 .move_to_element_with_offset(element, 0, 20).click()
             action.perform()
 
-    def click_learn_more_link(self, section_name):
-        xpath = "//h3[text()='"+ section_name + "']/../p/a/span[text()='Learn more']"
-        element = self.driver.find_element_by_xpath(xpath)
+    def click_link_with_id(self, link_id):
+        element = self.driver.find_element_by_id(link_id)
 
          # scroll the element into view so it can be
         # observed with SauceLabs screencast

--- a/test/browser_testing/features/steps/steps_navigation.py
+++ b/test/browser_testing/features/steps/steps_navigation.py
@@ -51,6 +51,11 @@ def step(context):
 def step(context, link_name):
     # Click the requested tab
     context.navigation.click_link(link_name)
+    
+@when(u'I click on the link with id "{link_id}"')
+def step(context, link_id):
+    # Click the requested tab
+    context.navigation.click_link_with_id(link_id)
 
 
 @then(u'I should see "{link_name}" displayed in the page title')
@@ -91,7 +96,3 @@ def step(context, relative_url, page_title):
     title = context.base.switch_to_new_tab(relative_url)
     assert_that(title, contains_string(page_title))
 
-@when(u'I click on the Learn more link inside "{section_name}"')
-def step(context, section_name):
-    # Click the learn more link inside "section_name"
-    context.navigation.click_learn_more_link(section_name)


### PR DESCRIPTION
### Changes
- Find landing page `learn more` links by id instead of xpath

### Additions
- Test landing page journey section header links

### Review
@cfarm 
@OrlandoSoto 