### PR TITLE
Journey tool fixes & illustration move to WP

### DIFF
--- a/src/_lib/wordpress_journey_processor.py
+++ b/src/_lib/wordpress_journey_processor.py
@@ -60,7 +60,7 @@ def process_journey(item):
                 if field_name in custom_fields:
                     if field == 'link':
                         tool['url'] = custom_fields[field_name][0]
-                        tool['text'] = custom_fields[field_name][0]
+                        tool['text'] = custom_fields[field_name][1]
                     else:
                         tool[field] = custom_fields[field_name][0]
 

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -109,7 +109,7 @@
                         <div class="content-l content-l__main">
 
                           {% if step.content %}
-                          <section class="{% if step.key_tool %}content-l_col-2-3{% else %}content-l_col-1{% endif %} content-l_col short-desc">
+                          <section class="{% if not active_phase.tools or step.key_tool%}content-l_col-2-3{% else %} step-content-full {% endif %} content-l_col short-desc">
                             <p>
                             {{step.content|safe}}          
                             </p>

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -42,9 +42,8 @@
               <div class="lead u-mb0">{{active_phase.content | safe if active_phase.content}}</div>
           </div>
           <div class="content-l_col content-l_col-1-4 phase_image">
-            {% if vars.process_steps and phase_index %}
-              {% set active_phase_short_name =  vars.process_steps[phase_index - 1]['url'] %}
-              <img src="{{url_for('static', filename='img/process_' + active_phase_short_name + '.png')}}" alt="Illustration of the home-buying process">
+            {% if active_phase.thumbnail %}
+              <img src="{{active_phase.thumbnail.images.full.url}}" alt="Illustration of the home-buying process">
             {% endif %}
           </div>
       </section>
@@ -75,7 +74,7 @@
                     {% if tool.text %}
                     <p class="short-desc">{{tool.description}}</p>
                     {% endif %}
-                    <a class="list_link jump-link jump-link__right" href="tool.url">
+                    <a class="list_link jump-link jump-link__right" href="{{tool.url}}">
                       {{tool.text}}
                     </a>
                   </div>
@@ -110,7 +109,7 @@
                         <div class="content-l content-l__main">
 
                           {% if step.content %}
-                          <section class="content-l_col-2-3 content-l_col short-desc">
+                          <section class="{% if step.key_tool %}content-l_col-2-3{% else %}content-l_col-1{% endif %} content-l_col short-desc">
                             <p>
                             {{step.content|safe}}          
                             </p>


### PR DESCRIPTION
### Changes
- Display tool text instead of url
- Correctly assign url to tool href attribute
- Show step description at full width when there is no key tool
- Move phase illustrations to WP

### Screenshots
![screen shot 2015-04-09 at 7 22 34 pm](https://cloud.githubusercontent.com/assets/778171/7079071/f30a8bd2-deed-11e4-8476-6a819ce1b4e5.png)

### Review
@cfarm 
@stephanieosan 
@sonnakim 
