### PR TITLE
Form explainer fix

### DIFF
--- a/src/form-explainer/closing-disclosure-1.html
+++ b/src/form-explainer/closing-disclosure-1.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/closing-disclosure-H25B-1.gif",
+"img": url_for('static', filename='img/closing-disclosure-H25B-1.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/closing-disclosure-2.html
+++ b/src/form-explainer/closing-disclosure-2.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/closing-disclosure-H25B-2.gif",
+"img": url_for('static', filename='img/closing-disclosure-H25B-2.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/closing-disclosure-3.html
+++ b/src/form-explainer/closing-disclosure-3.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/closing-disclosure-H25B-3.gif",
+"img": url_for('static', filename='img/closing-disclosure-H25B-3.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/closing-disclosure-4.html
+++ b/src/form-explainer/closing-disclosure-4.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/closing-disclosure-H25B-4.gif",
+"img": url_for('static', filename='img/closing-disclosure-H25B-4.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/closing-disclosure-5.html
+++ b/src/form-explainer/closing-disclosure-5.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/closing-disclosure-H25B-5.gif",
+"img": url_for('static', filename='img/closing-disclosure-H25B-5.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/index.html
+++ b/src/form-explainer/index.html
@@ -14,7 +14,7 @@
 
         <h1 class="page-title">Loan Estimate Explainer</h1>
         <p class="lead">When you receive a Loan Estimate, it should reflect a particular loan you discussed with a lender/broker. Check to see that everything matches your expectations. If something looks different from what you expected, talk to the lender/broker about the reason for the difference. Pay attention for red flags. If the explanation isn’t satisfactory, don’t keep working with that lender/broker.</p>
-        <a class="go-link" href="/owning-a-home/form-explainer/closing-disclosure.html">Already have a Closure Disclosure, explore it now</a>
+        <a class="go-link" href="/owning-a-home/form-explainer/closing-disclosure.html">Already have a Closing Disclosure, explore it now</a>
       </div><!-- /.page-intro -->
 
       <div class="col-4 illustration">

--- a/src/form-explainer/loan-estimate-1.html
+++ b/src/form-explainer/loan-estimate-1.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/loan-estimate-H24B-1.gif",
+"img": url_for('static', filename='img/loan-estimate-H24B-1.gif'),
 "terms":
 [
     {

--- a/src/form-explainer/loan-estimate-2.html
+++ b/src/form-explainer/loan-estimate-2.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/loan-estimate-H24B-2.gif",
+"img": url_for('static', filename='img/loan-estimate-H24B-2.gif'),
 'terms':
 [
     {

--- a/src/form-explainer/loan-estimate-3.html
+++ b/src/form-explainer/loan-estimate-3.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": "/owning-a-home/static/img/loan-estimate-H24B-3.gif",
+"img": url_for('static', filename='img/loan-estimate-H24B-3.gif'),
 'terms':
 [
 ]

--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -38,7 +38,6 @@ function fitAndStickToWindow( id ) {
       $terms =            $currentPage.find('.terms');
   // http://stackoverflow.com/questions/318630/get-real-image-width-and-height-with-javascript-in-safari-chrome
   $('<img/>')
-    .attr( 'src', $imageMapImage.attr('src') )
     .load( function() {
       // In order to make the image map sticky we must first make sure it will fit
       // completely within the window.
@@ -59,12 +58,19 @@ function fitAndStickToWindow( id ) {
       // When the sticky plugin is applied to the image, it adds position fixed,
       // and the image's width is no longer constrained to its parent.
       // To fix this we will give it its own width that is equal to the parent.
-      $imageMapImage.css( 'width', $imageMap.width() );
+      var containerWidth = $imageMap.width();
+      // IE8 wants a width on the wrapper too
+      $imageMapWrapper.width(containerWidth);
+      $imageMapImage.width(containerWidth);
       $imageMapWrapper.sticky({ topSpacing: 30 });
       if (id > 1) {
           $currentPage.hide();
       }
-    });
+    })
+    // This order is necessary so that IE8 doesn't fire the onload event
+    // before the src is set for cached images
+    // http://stackoverflow.com/questions/14429656/onload-callback-on-image-not-called-in-ie8
+    .attr( 'src', $imageMapImage.attr('src') );
 }
 
 /**

--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -61,6 +61,9 @@ function fitAndStickToWindow( id ) {
       // To fix this we will give it its own width that is equal to the parent.
       $imageMapImage.css( 'width', $imageMap.width() );
       $imageMapWrapper.sticky({ topSpacing: 30 });
+      if (id > 1) {
+          $currentPage.hide();
+      }
     });
 }
 
@@ -140,6 +143,10 @@ function initPage( id ) {
   if ( $WINDOW.width() >= 600 ) {
     // Resize the image, terms and pagination columns
     fitAndStickToWindow( id );
+  } else {
+      if ( id > 1 ) {
+         $currentPage.hide();
+      }
   }
   // Some form pages don't have content for every category so we need to create
   // placeholders for those categories informing the user.
@@ -197,9 +204,6 @@ $(document).ready(function(){
   $WRAPPER.find('.explain_page').each(function( index ) {
     var src = $( this ).find('.image-map_image').attr('src');
     initPage( index + 1 );
-    if ( index > 0 ) {
-      $( this ).hide();
-    }
   });
 
   if ( $WINDOW.width() >= 600 ) {


### PR DESCRIPTION
### Changes
- Fix 'closure' typo
- Don't hide form explainer pages until image size has been calculated
- IE8 fixes: assign onload callback before img attr in image resize function, and assign a width to $imageMapWrapper


### Screenshots
![screen shot 2015-04-20 at 4 39 00 pm](https://cloud.githubusercontent.com/assets/778171/7239993/e80d4fbc-e77b-11e4-847f-d1b31acc9c41.png)


### Review
@cfarm 