### PR TITLE
Journey: temporarily revert to using local phase images

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -42,8 +42,9 @@
               <div class="lead u-mb0">{{active_phase.content | safe if active_phase.content}}</div>
           </div>
           <div class="content-l_col content-l_col-1-4 phase_image">
-            {% if active_phase.thumbnail.images %}
-              <img src="{{active_phase.thumbnail.images.full.url}}" alt="Illustration of the home-buying process">
+            {% if vars.process_steps and phase_index %}
+              {% set active_phase_short_name =  vars.process_steps[phase_index - 1]['url'] %}	           
+              <img src="{{url_for('static', filename='img/process_' + active_phase_short_name + '.png')}}" alt="Illustration of the home-buying process">
             {% endif %}
           </div>
       </section>


### PR DESCRIPTION
### Changes
- use local images instead of WP ones for journey phases

### Review
- @cfarm 