### PR TITLE
Form explainer: grammatical fix

### DIFF
--- a/src/form-explainer/index.html
+++ b/src/form-explainer/index.html
@@ -14,7 +14,7 @@
 
         <h1 class="page-title">Loan Estimate Explainer</h1>
         <p class="lead">When you receive a Loan Estimate, it should reflect a particular loan you discussed with a lender/broker. Check to see that everything matches your expectations. If something looks different from what you expected, talk to the lender/broker about the reason for the difference. Pay attention for red flags. If the explanation isn’t satisfactory, don’t keep working with that lender/broker.</p>
-        <a class="go-link" href="/owning-a-home/form-explainer/closing-disclosure.html">Already have a Closing Disclosure, explore it now</a>
+        <a class="go-link" href="/owning-a-home/form-explainer/closing-disclosure.html">Already have a Closing Disclosure? Explore it now</a>
       </div><!-- /.page-intro -->
 
       <div class="col-4 illustration">


### PR DESCRIPTION
### Changes
- Closing disclosure link text should be in the form of a question (good catch, @cfarm!)

### Screenshots
![screen shot 2015-04-23 at 10 48 06 am](https://cloud.githubusercontent.com/assets/778171/7299827/3ef7aa76-e9a6-11e4-94ef-c1f06e40f5cf.png)

### Review
@cfarm 
