### PR TITLE
fix trailing slash to match the front end

### DIFF
--- a/test/browser_testing/features/loan_fha.feature
+++ b/test/browser_testing/features/loan_fha.feature
@@ -17,7 +17,7 @@ Scenario Outline: Test Navigational links in the FHA Loan page
 Examples:
   | link_name       	  	     | relative_url											            | page_title 	  |
   | Owning a Home              | /                                            | Owning a Home |
-  | Understand loan options    | /loan-options/  	    								        | Loan Options  |
+  | Understand loan options    | /loan-options  	    								        | Loan Options  |
   | More on mortgage insurance | /loan-options/FHA-loans/#mortgage-insurance  | Loan Options  |
 
 @smoke_testing @loan_options


### PR DESCRIPTION
This should fix current failing browser test on dev site

you can run 

`behave -k features/loan_fha.feature -t=~prod_only`

to test but it will still fail locally because of the URL structure, but should work on dev site.