### PR TITLE
Frontendbuild env

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -1,3 +1,5 @@
+export DEPLOY_ENV=DEV
+echo 'Environment variable DEPLOY_ENV set'
 export WORDPRESS=http://wordpress.domain
 echo 'Environment variable WORDPRESS set'
 workon sheer

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -1,5 +1,5 @@
 export DEPLOY_ENV=DEV
-echo 'Environment variable DEPLOY_ENV set'
+echo 'Environment variable DEPLOY_ENV is set as' $DEPLOY_ENV
 export WORDPRESS=http://wordpress.domain
 echo 'Environment variable WORDPRESS set'
 workon sheer

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -446,7 +446,7 @@ module.exports = function(grunt) {
           interrupt: true,
         },
         files: ['Gruntfile.js', 'src/static/js/app.js', 'src/static/js/modules/**/*.js', 'src/static/js/templates/**/*.hbs'],
-        tasks: ['build']
+        tasks: ['dev-deploy']
       },
       css: {
         options: {
@@ -460,7 +460,7 @@ module.exports = function(grunt) {
           interrupt: true,
         },
         files: ['Gruntfile.js', 'src/static/css/*.less', 'src/static/css/module/*.less', 'src/static/js/app.js', 'src/static/js/modules/**/*.js', 'src/static/js/templates/**/*.hbs', 'src/**/*.html', '_layouts/*'],
-        tasks: ['build']
+        tasks: ['dev-deploy']
       }
     }
 
@@ -486,11 +486,11 @@ module.exports = function(grunt) {
   grunt.registerTask('css', ['newer:less:watch', 'newer:autoprefixer']);
 
   grunt.registerTask('vendor', ['clean:bowerDir', 'bower:install', 'concat:cf-less']);
-  grunt.registerTask('build', ['reset', 'js', 'css', 'copy', 'concat:ie9', 'concat:ie8', 'test']);
+  grunt.registerTask('dev-deploy', ['reset', 'js', 'css', 'copy', 'concat:ie9', 'concat:ie8', 'test']);
   grunt.registerTask('ship', ['uglify', 'cssmin', 'usebanner']);
   grunt.registerTask('test', ['browserify:tests', 'mocha_istanbul']);
   grunt.registerTask('release', ['clean:dist', 'js', 'css', 'copy:release', 'copy:img', 'copy:fonts', 'concat:ie9', 'concat:ie8']);
-  grunt.registerTask('deploy', ['release', 'ship']);
-  grunt.registerTask('default', ['build', 'ship']);
+  grunt.registerTask('production-deploy', ['release', 'ship']);
+  grunt.registerTask('default', ['dev-deploy', 'ship']);
 
 };

--- a/frontendbuild.sh
+++ b/frontendbuild.sh
@@ -10,6 +10,6 @@ npm install
 
 if [ $DEPLOY_ENV = "PROD" ]; then
   grunt production-deploy
-elif [ $DEPLOY_ENV = "DEV" ]; then
+else
   grunt dev-deploy
 fi

--- a/frontendbuild.sh
+++ b/frontendbuild.sh
@@ -7,4 +7,9 @@ if [ ! -f config/config.json ]; then
 fi
 
 npm install
-grunt build
+
+if [ $DEPLOY_ENV = "PROD" ]; then
+  grunt production-deploy
+elif [ $DEPLOY_ENV = "DEV" ]; then
+  grunt dev-deploy
+fi


### PR DESCRIPTION
Fixes GHE#900#issuecomment-41489

## Changes
* Adds an environment variable to our .env_SAMPLE which devs should add to our local .env file
* Renames grunt tasks to match up with our various deployment environments: local/dev task is `dev-deploy`, release to production is `production-deploy`
* `frontendbuild.sh` checks the variable to run either `grunt production-deploy` or `grunt dev-deploy` depending on the environment

This will require changes to our build job(s) and production
This means we can remove inconsistent configurations for those jobs and just use `frontendbuild.sh` but we have to set the environment locally and in our deployment configs.

## Review
* does this make sense? are we using that environment variable for something else in our jobs? we can discuss over Office Hours if needed for Security Purposes @contolini @imuchnik @Ooblioob
* @virginiacc can you try out the renamed grunt tasks plus `frontendbuild.sh` to assure they work as expected?

## todos
* if merged we can maybe use this to write our URLs based on environment  (omgggg what a dream)
* if merged update jobs in all environments + the wiki front end deploy doc
* add similar updates to the old branch for #421