### PR TITLE
Form explainer copy updates

### DIFF
--- a/src/form-explainer/closing-disclosure-3.html
+++ b/src/form-explainer/closing-disclosure-3.html
@@ -25,7 +25,7 @@
     },
     {
         "term": "Paid Already by or on Behalf of Borrower at Closing",
-        "definition": "<p>This section details how you will pay for the items in Section K. It includes the amount you are borrowing, the amount you have already paid and any rebates or credits paid by the seller or third-party service providers.</p>",
+        "definition": "<p>This section details how you will pay for the items in Section K. It includes the amount you are borrowing, the amount you have already paid, and any rebates or credits paid by the seller or third-party service providers.</p>",
         "id": "paid-already",
         "category": "definitions",
         "left": "5.96%",

--- a/src/form-explainer/closing-disclosure.html
+++ b/src/form-explainer/closing-disclosure.html
@@ -14,8 +14,12 @@
 
         <h1 class="page-title">Closing Disclosure Explainer</h1>
         <p class="lead">Your lender should provide your Closing Disclosure three business days before your scheduled closing. Make sure to set aside time to review your Closing Disclosure in advance of closing. Check to see that everything matches your expectations. If something looks different from what you expected, talk to the lender/broker about the reason for the difference. Pay attention for red flags. If the explanation isn’t satisfactory, keep asking questions. Know that walking away at closing may be better than signing a deal you’re not comfortable with.</p>
-        <p>After you’ve reviewed below, make sure to <a class="pdf-link" href="{{ base_url }}resources/checklist_mortgage_closing.pdf">download our complete closing checklist</a>.</p>
-        <a class="go-link" href="/owning-a-home/form-explainer/">Have a Loan Estimate, explore it now</a>
+        
+        
+        <p>After you’ve reviewed below, <a class="jump-link jump-link__pdf" href="http://content.consumerfinance.gov/f/cfpb_closing_disclosure_resource_Final.pdf">
+            <span class="jump-link_text">here's what to do next in the closing process</span>
+        </a>.</p>
+        
       </div><!-- /.col-8.page-intro -->
 
       <div class="col-4 illustration">

--- a/src/form-explainer/index.html
+++ b/src/form-explainer/index.html
@@ -14,7 +14,22 @@
 
         <h1 class="page-title">Loan Estimate Explainer</h1>
         <p class="lead">When you receive a Loan Estimate, it should reflect a particular loan you discussed with a lender/broker. Check to see that everything matches your expectations. If something looks different from what you expected, talk to the lender/broker about the reason for the difference. Pay attention for red flags. If the explanation isn’t satisfactory, don’t keep working with that lender/broker.</p>
-        <a class="go-link" href="/owning-a-home/form-explainer/closing-disclosure.html">Already have a Closing Disclosure? Explore it now</a>
+        
+        <ul class="list list__links list__spaced">  
+          <li class="list_item">
+            <a class="list_link jump-link jump-link__right" href="http://content.consumerfinance.gov/f/cfpb_loan_estimate_resource_Final.pdf">
+              <span class="jump-link_text">Still have questions about your Loan Estimate? We can help.</span>
+            </a>
+          </li>
+          <li class="list_item">
+              <a class="list_link jump-link jump-link__right" href="/owning-a-home/form-explainer/closing-disclosure.html">
+                <span class="jump-link_text">Already have a Closing Disclosure? Explore it now</span>
+              </a>
+            </li>
+          
+        </ul>
+          
+        
       </div><!-- /.page-intro -->
 
       <div class="col-4 illustration">

--- a/src/form-explainer/loan-estimate-1.html
+++ b/src/form-explainer/loan-estimate-1.html
@@ -14,7 +14,7 @@
         "height": "4.50%"
     },
     {
-        "term": "Check loan terms, purpose, product and type",
+        "term": "Check loan terms, purpose, product, and type",
         "definition": "<p>Make sure the info matches what you discussed with your lender or broker.</p>",
         "id": "check-term",
         "category": "checklist",

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -37,6 +37,20 @@
   .list_link {
     .respond-to-max(@mobile-max, {
       .block-link();
+      border-color: @link-underline;
+
+       &:visited {
+         border-color: @link-underline-visited;
+       }
+
+       &:hover {
+         border-color: @link-underline-hover;
+         z-index: 10;
+       }
+
+       &:active{
+         border-color: @link-underline-active;
+       }
 
       &.icon-link:after {
         position: absolute;


### PR DESCRIPTION
### Changes
- Fix commas in explainer text
- Update links on loan estimate & closing disclosure pages