### PR TITLE
Remove maintain from landing page and navigation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -157,38 +157,6 @@
             </div><!-- .content-l -->
           </section>
 
-          <section class="section__phase block__border-top block__padded-top block__sub">
-            
-            <div class="content-l">  
-
-              <figure class="phase_illu content-l_col content-l_col-1-4">
-                <img src="{{url_for('static', filename='img/process_maintain-small.png')}}" alt="Illustration of the home-buying process">
-              </figure>
-
-              <div class="phase_intro content-l_col content-l_col-1-2">
-                <div class="content-l_col content-l_col-1 content-l__large-gutters">
-                <h3 class="u-mb15"><a href="{{ base_url }}process/maintain" class="heading_link" id="maintain-header-link">Maintain your mortgage</a></h3>
-                <p>Congratulations! You've closed on your new home. Get tips for how to manage your mortgage to your advantage, and what to do if you're struggling to make your payments.</p>
-                <p>
-                  <a class="icon-link icon-link__right" href="{{ base_url }}process/maintain" id="maintain-learn-link">
-                    <span class="icon-link_text">Learn more</span>
-                  </a>
-                </p>
-                </div>
-              </div>
-
-               <div class="phase_tools content-l_col content-l_col-1-4 block__sub grid_column__left-divider">
-                <h6 class="block__sub block__flush-top">Key tools</h6>
-                <ul class="list__unstyled list__spaced">
-                  <li class="list_item"><a href="/complaint">Submit a complaint</a></li>
-                  <li class="list_item"><a href="/find-a-housing-counselor/">Find a housing counselor</a></li>
-                </ul>
-              </div>          
-
-            </div><!-- .content-l -->
-
-          </section>
-
         </section><!-- .content_main -->
 
         <aside class="content_sidebar">

--- a/src/process/_vars-process.html
+++ b/src/process/_vars-process.html
@@ -19,11 +19,6 @@
             "url": "decide",
             "title": "Decide <br/>and close",
             "slug": "decide-and-close"
-        },
-        {
-            "url": "maintain",
-            "title": "Maintain <br/>your mortgage",
-            "slug": "maintain-your-mortgage"
         }
     ]
 %}


### PR DESCRIPTION
## Removes

* Remove maintain from landing page
* Remove maintain on top and bottom navigation

## Review

@virginiacc @cfarm @huetingj @stephanieosan 

## Screenshot

Landing Page:
![screen shot 2015-06-02 at 1 01 04 pm](https://cloud.githubusercontent.com/assets/2673022/7941885/5042db24-0928-11e5-9d86-196f64a37c0d.png)
![screen shot 2015-06-02 at 1 02 17 pm](https://cloud.githubusercontent.com/assets/2673022/7941892/593a0f04-0928-11e5-8c4f-372b55692508.png)


Navigation:
![screen shot 2015-06-02 at 12 57 34 pm](https://cloud.githubusercontent.com/assets/2673022/7941899/685bc39c-0928-11e5-8cb9-7a6f6a9744fc.png)
![screen shot 2015-06-02 at 12 58 07 pm](https://cloud.githubusercontent.com/assets/2673022/7941903/6ad30b8a-0928-11e5-92bd-4ce1e2620c47.png)
![screen shot 2015-06-02 at 1 01 43 pm](https://cloud.githubusercontent.com/assets/2673022/7941909/7539ad04-0928-11e5-9440-de331f2f4be9.png)
![screen shot 2015-06-02 at 1 01 56 pm](https://cloud.githubusercontent.com/assets/2673022/7941910/7744b42c-0928-11e5-8753-414abf8303ab.png)

