### PR TITLE
Fix template variable

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -123,7 +123,7 @@
                               <span class="cf-icon cf-icon-attach"></span>&nbsp;Key tool
                             </h4>
                             <a class="jump-link jump-link__right" href="{{step.key_tool.url}}">
-                              <span class="jump-link_text">{{step.key_tool.text}}</span>
+                              <span class="jump-link_text">{{step.key_tool.label}}</span>
                             </a>
                           </section>
                           {% endif %}


### PR DESCRIPTION
The template variable is now called `label` not `text`.