### PR TITLE
Downpayment & loan input display updates

### DIFF
--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -154,10 +154,6 @@
   .webfont-regular();
   position: relative;
   
-  .respond-to-min(@tablet-min, {
-    padding-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
-  });
-  
   .comparison-header {
     .u-hide-on-mobile;
   }
@@ -844,7 +840,7 @@
         }
       }
       
-      &.independent {
+      &.highlight {
         td {
           background-color: @green-tint;
 
@@ -941,4 +937,31 @@
   margin-bottom: 5px;
 }
 
-
+/* Makes loan input table background appear flush
+   with left side of screen on desktop */
+#loan-input-table {
+  .respond-to-min(795px, { 
+    td:first-child,
+    th:first-child {
+      position: relative;
+      border-width: 0;
+      &:before{
+          position:absolute;
+          content: '';
+          top: 0;
+          left: -200%;
+          height: 100%;
+          background-color: @gray-5;
+          width: 200%;
+      }
+    }
+    tr.highlight {
+      td:first-child {
+        border-width: 0;
+        &:before {
+          background-color: @green-tint;
+        }
+      }
+    }
+  });
+}

--- a/src/static/js/modules/loan-comparison/components/loan-input-downpayment.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-downpayment.js
@@ -5,25 +5,6 @@ var assign = require('object-assign');
 var mortgageCalculations = require('../mortgage-calculations');
 
 var LoanDownpaymentInput = React.createClass({
-    getInitialState: function () {
-        return this.getDownpaymentState(this.props.loan);
-    },
-    componentWillReceiveProps: function (nextProps) {
-        this.setState(this.getDownpaymentState(nextProps.loan));
-    },
-    getDownpaymentState: function (loan) {
-        return {
-            'downpayment': loan['downpayment'],
-            'downpayment-percent': mortgageCalculations['downpayment-percent'](loan)
-        };
-    },
-    updateDownpayment: function (percent) {
-        this.setState({
-            'downpayment-percent': percent,
-            'downpayment': mortgageCalculations['downpayment'](assign({}, this.props.loan, {'downpayment-percent': percent}))
-        });
-        this.props.onChange(this.state.downpayment);
-    },
     // TODO: move error display to table-row?
     showError: function() {
         var loan = this.props.loan;
@@ -38,16 +19,16 @@ var LoanDownpaymentInput = React.createClass({
         return (
             <div>
                 <TextInput
-                    value={this.state['downpayment-percent']}
+                    value={this.props.loan['downpayment-percent']}
                     className='small-input percent-input' 
                     maxLength='2' 
                     placeholder='10' 
-                    onChange={this.updateDownpayment}/>
+                    onChange={this.props.onChange.bind(this, 'downpayment-percent')}/>
                 <TextInput 
-                    value={this.state['downpayment']}
+                    value={this.props.loan['downpayment']}
                     className='mid-input dollar-input' 
                     placeholder='20,000' 
-                    onChange={this.props.onChange}/>
+                    onChange={this.props.onChange.bind(this, 'downpayment')}/>
                 <ErrorMessage opts={{showMessage: this.showError}}/>
             </div>
         );

--- a/src/static/js/modules/loan-comparison/components/loan-input-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-table-row.js
@@ -69,7 +69,7 @@ var LoanInputRow = React.createClass({
             // independent inputs. Get the note for this row's prop, if one exists, & use
             // the note's existence to determine a type, linked or independent, for the row.
             note = (scenario.inputNotes || {})[prop];
-            rowType = note ? 'independent' : 'linked';
+            rowType = note ? 'highlight' : 'linked';
         }
         
         return (

--- a/src/static/js/modules/loan-comparison/mortgage-calculations.js
+++ b/src/static/js/modules/loan-comparison/mortgage-calculations.js
@@ -9,7 +9,7 @@ var INSURANCE_RATE = 0.005;
 var mortgage = {};
 
 mortgage['loan-amount'] = function (loan) {
-    return loan['price'] - loan['downpayment'] || 0;
+    return +loan['price'] - +loan['downpayment'] || 0;
 };
 
 mortgage['discount'] = function (loan) {
@@ -105,7 +105,7 @@ mortgage['monthly-payment'] = function (loan) {
 };
 
 mortgage['closing-costs'] = function (loan) {
-    return loan['downpayment']
+    return +loan['downpayment']
             + loan['discount']
             + loan['processing']
             + loan['third-party-services']
@@ -120,7 +120,7 @@ mortgage['get-cost'] = function (loan) {
         amountBorrowed: positive(loan['loan-amount']),
         rate: loan['interest-rate'],
         totalTerm: loan['loan-term'] * 12,
-        downPayment: loan['downpayment'],
+        downPayment: +loan['downpayment'],
         closingCosts: loan['closing-costs']
     });
 };


### PR DESCRIPTION
### Additions
- Add flush-left styling to inputs table on desktop

### Changes
- Fix concatenation bug in closing costs calculation by ensuring that `downpayment` is a number
- Move `downpayment-percent` calculation out of downpayment component, since this value needs to be displayed in the mobile loan summary section
- Update `loan-input-table-cell` to accommodate change to dp component, and to break component props generation into several methods
- Add `updateDependencies` method back to loan store to calculate dp/dp-percent
- Refactor loan store's `updateLoan` function slightly so it can also be used by `resetLoans`

### Screenshots

![screen shot 2015-06-04 at 12 47 05 pm](https://cloud.githubusercontent.com/assets/778171/7989507/d7b5a998-0ab7-11e5-83b5-a5e679453687.png)

### Review
@cfarm 
@huetingj 
@stephanieosan 