### PR TITLE
Update processor to work with bulk indexing

### DIFF
--- a/src/_lib/wordpress_journey_processor.py
+++ b/src/_lib/wordpress_journey_processor.py
@@ -86,4 +86,7 @@ def process_journey(item):
 
     del item['custom_fields']
 
-    return item
+    return {'_index': 'content',
+            '_type': 'journey',
+            '_id': item['slug'],
+            '_source': item}


### PR DESCRIPTION
**WARNING: This PR requires an update to sheer, specifically [this PR](https://github.com/cfpb/sheer/pull/104). Only merge this if and when that PR is merged, and the servers/developers have upgraded sheer.**

This update greatly speeds up the Elasticsearch indexing process by using bulk indexing instead of indexing each document individually. See the aforementioned PR for more information.