### PR TITLE
Display notes

### DIFF
--- a/src/loan-comparison/index.html
+++ b/src/loan-comparison/index.html
@@ -26,7 +26,7 @@
 
     </section> <!-- ./comparisons -->
 
-  <div class="content_wrapper content_wrapper__narrow u-pb0">
+  <div class="content_wrapper content_wrapper__medium u-pb0">
     <div class="content_main u-pb0">
        <div class="block block__border-top block__flush-top block__flush-bottom">
 

--- a/src/static/css/module/bootstrap-tooltips.less
+++ b/src/static/css/module/bootstrap-tooltips.less
@@ -20,3 +20,4 @@
 @tooltip-arrow-width:         5px;
 @tooltip-arrow-color:         @tooltip-bg;
 @zindex-tooltip:           1030;
+

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -740,18 +740,23 @@
     }
   }
   
-  table.unstyled {
-    background: none;
-      
-    thead {
-      background: none;
+}
+
+table.unstyled {
+  background: none;
     
-      th {
-        color: @black;
-        background: none;
-      }
-    }  
-  }
+  thead {
+    background: none;
+  
+    th {
+      color: @black;
+      background: none;
+    }
+  } 
+  tbody > tr:nth-child(odd) > th,
+  tbody > tr:nth-child(odd) > td {
+      background: none;
+  } 
 }
 
 .scenario-alternates {
@@ -834,14 +839,14 @@
 }
 
 
-#loan-input-table {
+.loan-input-table {
   width: 100%;
   position: relative;
   
   select {
     font-size: unit(14px / @base-font-size-px, em);
   }
-
+  
   th,
   td {
       width: 33%;
@@ -854,11 +859,7 @@
       
       &.input-1 {
         padding-left: unit(8px / @base-font-size-px, em);
-      }
-
-      tbody > tr:nth-child(odd) > & {
-          background: none;
-      }
+      }      
       
       &.link {
         width: 20px;

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -157,10 +157,6 @@
   .comparison-header {
     .u-hide-on-mobile;
   }
-  
-  .help-text {
-    display: none;
-  }
 
   input[type="text"] {
     width: 100%;
@@ -1039,6 +1035,15 @@
   }
 }
 
+/* Tooltips */
 .tooltip {
   .webfont-regular();
+  .tooltip-inner {
+    max-width: 325px;
+  }
+}
+
+
+.help-text {
+  display: none;
 }

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -746,7 +746,6 @@
   
   table.unstyled {
     background: none;
-    width: 100%;
       
     thead {
       background: none;
@@ -755,106 +754,7 @@
         color: @black;
         background: none;
       }
-    }    
-  
-    th,
-    td {
-        width: 33%;
-        padding: unit(12px / @base-font-size-px, em) unit(15px / @base-font-size-px, em);
-        background-color: @gray-5;
-        
-        &.input-0 {
-          padding-right: unit(8px / @base-font-size-px, em);
-        }
-        
-        &.input-1 {
-          padding-left: unit(8px / @base-font-size-px, em);
-        }
-
-        tbody > tr:nth-child(odd) > & {
-            background: none;
-        }
-        
-        &.link {
-          width: 20px;
-          padding-left: 0;
-          padding-right: 0;
-          font-size: unit(20px / @base-font-size-px, em);
-          color: @gray;
-        }
-    }
-  
-    td {
-      vertical-align: top;
-    
-      &.label-cell {
-        text-align: right;
-      }
-      
-      &.header-cell, 
-      &.label-cell {
-        padding-left: @grid_gutter-width;
-      }
-      
-      &.link {
-        span {
-          display: none;
-        }
-      }
-    }
-  
-    tr {
-      border: none;
-      
-      &.padded-row {
-        td.label-cell {
-          padding-top: 1em;
-        }
-        td.link {
-          padding-top: .9em;
-        }
-      }
-      
-      &.linked {
-        td.input-1 {
-          color: @gray-80;
-
-          .select-content,
-          input[type="text"] {
-            border-color: @gray-20;
-          }
-
-          .select-content {
-            background: #fff url('../img/select.png') no-repeat right -63px;
-          }
-
-          select {
-            color: @gray-80;
-            font-style: normal !important;
-          }        
-        }
-        td.link {
-          span {
-            display: block;
-          }
-        }
-      }
-      
-      &.highlight {
-        td {
-          background-color: @green-tint;
-
-          .select-content,
-          input[type="text"] {
-            border-width: 2px;
-            border-color: @green;
-          }
-        }
-      }
-      
-    }
-    
-   
+    }  
   }
 }
 
@@ -937,9 +837,143 @@
   margin-bottom: 5px;
 }
 
-/* Makes loan input table background appear flush
-   with left side of screen on desktop */
+
 #loan-input-table {
+  width: 100%;
+  position: relative;
+  
+  select {
+    font-size: unit(14px / @base-font-size-px, em);
+  }
+
+  th,
+  td {
+      width: 33%;
+      padding: unit(12px / @base-font-size-px, em) unit(15px / @base-font-size-px, em);
+      background-color: @gray-5;
+      
+      &.input-0 {
+        padding-right: unit(8px / @base-font-size-px, em);
+      }
+      
+      &.input-1 {
+        padding-left: unit(8px / @base-font-size-px, em);
+      }
+
+      tbody > tr:nth-child(odd) > & {
+          background: none;
+      }
+      
+      &.link {
+        width: 20px;
+        padding-left: 0;
+        padding-right: 0;
+        font-size: unit(20px / @base-font-size-px, em);
+        color: @gray;
+      }
+  }
+
+  td {
+    vertical-align: top;
+  
+    &.label-cell {
+      text-align: right;
+    }
+    
+    &.header-cell, 
+    &.label-cell {
+      padding-left: @grid_gutter-width;
+    }
+    
+    &.link {
+      span {
+        display: none;
+      }
+    }
+  }
+  
+  .label-text {
+    .webfont-medium();
+    .u-inline-block;
+    padding-right: 3px;
+  }
+
+  tr {
+    border: none;
+    
+    &.header-row {
+      h3 {
+        padding-left: @grid_gutter-width * 1.5;
+        padding-top: @grid_gutter-width;
+      }
+    }
+    
+    &.subhead-row {
+      padding-bottom: 0;
+      
+      h4 {
+        text-align: center;
+        margin-bottom: 0;
+      }
+    }
+    
+    &.output-row {
+      .label-text {
+        .h5;
+        border-bottom: none;
+      }
+    }
+    
+    &.padded-row {
+      td.label-cell {
+        padding-top: 1em;
+      }
+      td.link {
+        padding-top: .9em;
+      }
+    }
+    
+    &.linked {
+      td.input-1 {
+        color: @gray-80;
+
+        .select-content,
+        input[type="text"] {
+          border-color: @gray-20;
+        }
+
+        .select-content {
+          background: #fff url('../img/select.png') no-repeat right -63px;
+        }
+
+        select {
+          color: @gray-80;
+          font-style: normal !important;
+        }        
+      }
+      td.link {
+        span {
+          display: block;
+        }
+      }
+    }
+    
+    &.highlight {
+      td {
+        background-color: @green-tint;
+
+        .select-content,
+        input[type="text"] {
+          border-width: 2px;
+          border-color: @green;
+        }
+      }
+    }
+    
+  }
+  
+  /* Makes loan input table background appear flush
+     with left side of screen on desktop */
   .respond-to-min(795px, { 
     td:first-child,
     th:first-child {
@@ -964,4 +998,47 @@
       }
     }
   });
+}
+
+.educational-note {
+  .respond-to-min(795px, { 
+  
+    padding: 0;
+    height: 0;
+    width: 0;
+  
+    div {
+      position: absolute;
+      margin-left: @grid_gutter-width;
+      width: 33%;
+      border: 2px solid @green-tint;
+      padding: @grid_gutter-width/2;
+      text-align: left;
+    }
+  
+    p {
+      color: @text;
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: unit(@base-font-size-px / 16 * 100, %);
+      line-height: @base-line-height;
+      text-align: left;
+    }
+  
+    .lc-results-table & {
+      div {
+         top: 0;
+         margin-left: @grid_gutter-width/2;
+       }
+    }
+  });
+}
+
+.lc-results-table {
+  tr {
+    position: relative;
+  }
+}
+
+.tooltip {
+  .webfont-regular();
 }

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -154,10 +154,6 @@
   .webfont-regular();
   position: relative;
   
-  .respond-to-min(@tablet-min, {
-    padding-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
-  });
-  
   .comparison-header {
     .u-hide-on-mobile;
   }
@@ -844,7 +840,7 @@
         }
       }
       
-      &.independent {
+      &.highlight {
         td {
           background-color: @green-tint;
 
@@ -941,4 +937,31 @@
   margin-bottom: 5px;
 }
 
-
+/* Makes loan input table background appear flush
+   with left side of screen on desktop */
+#loan-input-table {
+  .respond-to-min(795px, { 
+    td:first-child,
+    th:first-child {
+      position: relative;
+      border-width: 0;
+      &:before{
+          position:absolute;
+          content: '';
+          top: 0;
+          left: -200%;
+          height: 100%;
+          background-color: @gray-5;
+          width: 200%;
+      }
+    }
+    tr.highlight {
+      td:first-child {
+        border-width: 0;
+        &:before {
+          background-color: @green-tint;
+        }
+      }
+    }
+  });
+}

--- a/src/static/js/modules/loan-comparison/common.js
+++ b/src/static/js/modules/loan-comparison/common.js
@@ -187,7 +187,7 @@ common.getPropLabel = function (prop) {
 
 common.propLabels = {
     'downpayment': 'Down payment',
-    'points':      'Discount point and credits',
+    'points':      '<span>Discount points<br/>and credits</span>',
     'arm-type':    'ARM type',
     'rate-structure': 'Rate type',
     'price': 'House price',

--- a/src/static/js/modules/loan-comparison/common.js
+++ b/src/static/js/modules/loan-comparison/common.js
@@ -21,8 +21,8 @@ common.scenarios = [
         label: 'down payment',
         intro: "Your down payment amount affects all aspects of your costs. Putting down less up front can be a good option for home buyers without a lot of cash on hand, but you’ll have higher monthly payments and pay more in interest and fees. This tool will help you get a sense of how much the difference in costs is likely to be, so you can make tradeoffs.",
         loanProps: [
-            {downpayment: 40000}, 
-            {downpayment: 20000}
+            {'downpayment-percent': 20},
+            {'downpayment-percent': 10}
         ],
         sharedProps: {},
         inputNotes: {
@@ -44,7 +44,29 @@ common.scenarios = [
 common.defaultScenario = common.scenarios[0];
 
 common.inputTooltips = {
-    'state': 'State tooltip'
+    'state': 'The state where the home is located',
+    'county': 'The county where the home is located',
+    'credit-score': 'A number that is used to predict how likely you are to pay back a loan on time. You can find out how to get this number here: http://www.consumerfinance.gov/askcfpb/316/where-can-i-get-my-credit-score.html',
+    'price': 'The price of the home',
+    'downpayment': 'The initial, upfront payment you make toward the total cost of the home. ',
+    'loan-amount': 'The amount of money borrowed to pay for the home. Calculated by subtracting the down payment from the home price.',
+    'rate-structure': 'Choose between a fixed rate, where your interest rate does not change over the term of your loan, or adjustable rate where it can change.',
+    'arm-type': 'Adjustable Rate Mortgages have both fixed periods and adjustable periods. The top number is the fixed period. The bottom number is the adjustable period. Learn more here:http://www.consumerfinance.gov/owning-a-home/loan-options/',
+    'loan-term': 'The amount of time the borrower has to repay the loan.',
+    'loan-type': 'Loans are categorized based on the size of the loan and whether they are part of a government program. Learn more here: http://www.consumerfinance.gov/owning-a-home/loan-options/',
+    'loan-summary': 'This field summarizes your loan type, term, and rate type.',
+    'points': 'Points lower the interest rate by closing costs. Credits lower closing costs by increasing the interest rate. Learn more here: http://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-or-points.html',
+    'interest-rate': 'The cost paid each year to borrow the money, expressed as a percentage rate. It does not reflect fees or any other charges paid for the loan.'
+};
+common.outputTooltips = {
+    'downpayment': 'The amount paid upfront for the home.',
+    'lender-fees': 'Fees paid to the lender to process the mortgage. Paid as part of the closing costs.',
+    'third-party-fees': 'Fees paid for services provided by a third party, not your lender. Includes title insurance fees, appraisal fees, and homeowner’s insurance. Paid as part of the closing costs.',
+    'taxes-gov-fees': 'Includes fees paid to the government, transfer taxes, and property taxes. Paid as part of the closing costs.',
+    'prepaid-expenses': 'Fees required to be paid at closing, before they are due, such as accrued interest.',
+    'initial-escrow': 'The amount paid at closing to start your escrow account, if required by your lender. Learn more: http://www.consumerfinance.gov/askcfpb/160/what-is-an-initial-escrow-deposit.html',
+    'monthly-principal-interest': 'The amount paid each month toward the loan balance combined with the amount paid each month in interest costs.',
+    'monthly-mortgage-insurance': 'A monthly fee paid to the lender if the down payment was less than 20 percent. Mortgage insurance protects the lender, not the borrower.'
 }
 
 // Options can be an array of objects with "label" & "val" properties,

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -40,31 +40,44 @@ var App = React.createClass({
         });
         $('.expandable').expandable();
         
-        var animating;
+        var animating, scenario = this.state.scenario;
+
         // initial positioning of educational notes
-        positionNotes();
+        if (scenario) {
+            positionNotes();
+        }
         
         $(window).resize(debounce(function () {
-            positionNotes(animating);
+            if (scenario) {
+                positionNotes(animating);
+            }
         }, 100));
         
         // reposition notes on start of expand event
         // and (approximate) completion of expandable animation
         // (could also update cf-expandable to allow callbacks)
         $('.expandable_target').click(function () {
-            var $parent = $(this).closest('.expandable');
-            animating = true;
-            positionNotes(animating, $parent);
-            
-            setTimeout(function () {
-                animating = false;
+            if (scenario) {
+                var $parent = $(this).closest('.expandable');
+                animating = true;
                 positionNotes(animating, $parent);
-            }, 1000)
+
+                setTimeout(function () {
+                    animating = false;
+                    positionNotes(animating, $parent);
+                }, 1000);
+            }
         });
     },
   
     componentWillUnmount: function() {
         LoanStore.removeChangeListener(this._onChange);
+    },
+    
+    componentDidUpdate: function () {
+        if (this.state.scenario) {
+            positionNotes();
+        }
     },
 
     render: function() {

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -28,6 +28,9 @@ var App = React.createClass({
     },
     
     componentDidMount: function() {
+        var scenario = this.state.scenario;
+        var animating; 
+        
         LoanStore.addChangeListener(this._onChange);
         // tooltips
         $(this.getDOMNode()).tooltip({
@@ -38,9 +41,7 @@ var App = React.createClass({
                 return $(this).attr('title') || $(this).next('.help-text').html() || 'Tooltip information.';
             }
         });
-        $('.expandable').expandable();
-        
-        var animating, scenario = this.state.scenario;
+        $('.expandable').expandable();        
 
         // initial positioning of educational notes
         if (scenario) {

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -1,4 +1,6 @@
 var React = require('react');
+var debounce = require('debounce');
+
 var LoanStore = require('../stores/loan-store');
 var ScenarioStore = require('../stores/scenario-store');
 var LoanInputTable = require('./loan-input-table');
@@ -7,6 +9,7 @@ var LoanOutputTableGroup = require('./loan-output-table');
 var LoanOutputTableMobileGroup = require('./loan-output-table-mobile');
 var ScenarioHeader = require('./scenario-header');
 var NextSteps = require('./next-steps');
+var positionNotes = require('../position-notes');
 
 var $ = jQuery = require('jquery');
 require('tooltips');
@@ -30,11 +33,34 @@ var App = React.createClass({
         $(this.getDOMNode()).tooltip({
             selector: '[data-toggle="tooltip"]',
             'placement': 'bottom', 
+            container: 'body',
             title: function getTooltipTitle(){
                 return $(this).attr('title') || $(this).next('.help-text').html() || 'Tooltip information.';
             }
         });
         $('.expandable').expandable();
+        
+        var animating;
+        // initial positioning of educational notes
+        positionNotes();
+        
+        $(window).resize(debounce(function () {
+            positionNotes(animating);
+        }, 100));
+        
+        // reposition notes on start of expand event
+        // and (approximate) completion of expandable animation
+        // (could also update cf-expandable to allow callbacks)
+        $('.expandable_target').click(function () {
+            var $parent = $(this).closest('.expandable');
+            animating = true;
+            positionNotes(animating, $parent);
+            
+            setTimeout(function () {
+                animating = false;
+                positionNotes(animating, $parent);
+            }, 1000)
+        });
     },
   
     componentWillUnmount: function() {
@@ -69,9 +95,7 @@ var App = React.createClass({
                 </div>
                 <LoanOutputTableGroup loans={this.state.loans} scenario={this.state.scenario} />
             </div>
-            <div>
-                <NextSteps scenario={this.state.scenario}/>
-            </div>
+            <NextSteps scenario={this.state.scenario}/>
           </div>
         );
     },

--- a/src/static/js/modules/loan-comparison/components/educational-note.js
+++ b/src/static/js/modules/loan-comparison/components/educational-note.js
@@ -1,0 +1,18 @@
+var React = require('react');
+
+var EducationalNote = React.createClass({
+    render: function() {
+        return (
+            <div className={this.props.type}>
+                <h5>
+                    {this.props.label}
+                </h5>
+                <p className="u-mb0">
+                    {this.props.note}
+                </p>
+            </div>
+        );
+    }
+});
+
+module.exports = EducationalNote;

--- a/src/static/js/modules/loan-comparison/components/loan-input-downpayment.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-downpayment.js
@@ -5,25 +5,6 @@ var assign = require('object-assign');
 var mortgageCalculations = require('../mortgage-calculations');
 
 var LoanDownpaymentInput = React.createClass({
-    getInitialState: function () {
-        return this.getDownpaymentState(this.props.loan);
-    },
-    componentWillReceiveProps: function (nextProps) {
-        this.setState(this.getDownpaymentState(nextProps.loan));
-    },
-    getDownpaymentState: function (loan) {
-        return {
-            'downpayment': loan['downpayment'],
-            'downpayment-percent': mortgageCalculations['downpayment-percent'](loan)
-        };
-    },
-    updateDownpayment: function (percent) {
-        this.setState({
-            'downpayment-percent': percent,
-            'downpayment': mortgageCalculations['downpayment'](assign({}, this.props.loan, {'downpayment-percent': percent}))
-        });
-        this.props.onChange(this.state.downpayment);
-    },
     // TODO: move error display to table-row?
     showError: function() {
         var loan = this.props.loan;
@@ -38,16 +19,16 @@ var LoanDownpaymentInput = React.createClass({
         return (
             <div>
                 <TextInput
-                    value={this.state['downpayment-percent']}
+                    value={this.props.loan['downpayment-percent']}
                     className='small-input percent-input' 
                     maxLength='2' 
                     placeholder='10' 
-                    onChange={this.updateDownpayment}/>
+                    onChange={this.props.onChange.bind(this, 'downpayment-percent')}/>
                 <TextInput 
-                    value={this.state['downpayment']}
+                    value={this.props.loan['downpayment']}
                     className='mid-input dollar-input' 
                     placeholder='20,000' 
-                    onChange={this.props.onChange}/>
+                    onChange={this.props.onChange.bind(this, 'downpayment')}/>
                 <ErrorMessage opts={{showMessage: this.showError}}/>
             </div>
         );

--- a/src/static/js/modules/loan-comparison/components/loan-input-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-table-row.js
@@ -69,7 +69,7 @@ var LoanInputRow = React.createClass({
             // independent inputs. Get the note for this row's prop, if one exists, & use
             // the note's existence to determine a type, linked or independent, for the row.
             note = (scenario.inputNotes || {})[prop];
-            rowType = note ? 'independent' : 'linked';
+            rowType = note ? 'highlight' : 'linked';
         }
         
         return (

--- a/src/static/js/modules/loan-comparison/components/loan-input-table.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-table.js
@@ -11,19 +11,19 @@ var LoanInputTable = React.createClass({
     render: function() { 
         return (
             <table className="unstyled" id="loan-input-table">
-                <tr className="header-row"><th colSpan="3">1. About you</th></tr>
-                <tr>
+                <tr className="header-row"><th colSpan="4"><h3>1. About you</h3></th></tr>
+                <tr className="subhead-row">
                     <th></th>
-                    <th className="input-0">Scenario A</th>
+                    <th className="input-0"><h4>Scenario A</h4></th>
                     <th className="link"></th>
-                    <th className="input-1">Scenario B</th>
+                    <th className="input-1"><h4>Scenario B</h4></th>
                 </tr>
                 {this.inputRows(['state', 'county', 'credit-score'])}
                 
-                <tr className="header-row"><th colSpan="3">2. About the home</th></tr>
+                <tr className="header-row"><th colSpan="4"><h3>2. About the home</h3></th></tr>
                 {this.inputRows(['price', 'downpayment', 'loan-amount'])}
 
-                <tr className="header-row"><th colSpan="3">3. About the loan</th></tr>
+                <tr className="header-row"><th colSpan="4"><h3>3. About the loan</h3></th></tr>
                 {this.inputRows(['rate-structure', 'arm-type', 'loan-term', 'loan-type', 'loan-summary', 'points'])}     
 
                 {this.inputRows(['interest-rate'])}

--- a/src/static/js/modules/loan-comparison/components/loan-input-table.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-table.js
@@ -10,7 +10,7 @@ var LoanInputTable = React.createClass({
     },
     render: function() { 
         return (
-            <table className="unstyled" id="loan-input-table">
+            <table className="unstyled loan-input-table">
                 <tr className="header-row"><th colSpan="4"><h3>1. About you</h3></th></tr>
                 <tr className="subhead-row">
                     <th></th>

--- a/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
@@ -1,6 +1,8 @@
 var React = require('react');
 var LoanOutputCell = require('./loan-output-table-cell');
 var EducationalNote = require('./educational-note');
+var common = require('../common');
+var Tooltip = require('./tooltip');
 
 var LoanOutputRow = React.createClass({
     displayClassNames: function(type) {
@@ -8,6 +10,9 @@ var LoanOutputRow = React.createClass({
         return typeClass;        
     },
     render: function () {
+        var tooltipHtml = common.outputTooltips[this.props.prop]
+                          ? <Tooltip text={common.outputTooltips[this.props.prop]}/>
+                          : null;
         var headingType = function (prop, type, label, scenario) {
             if (type === 'primary') {
                 return (
@@ -19,6 +24,7 @@ var LoanOutputRow = React.createClass({
                         <h6>
                             {label}
                         </h6>
+                        {tooltipHtml}
                     </th>
                 );
             } else {
@@ -26,7 +32,7 @@ var LoanOutputRow = React.createClass({
                     <th scope="colgroup">
                         <h5>
                             {label}&nbsp;
-                            <span className="lc-tooltip" data-toggle="tooltip" role="tooltip" data-original-title="" title=""><span className="cf-icon cf-icon-help-round"></span></span>
+                            {tooltipHtml}
                         </h5>
                     </th>
                 );

--- a/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var LoanOutputCell = require('./loan-output-table-cell');
+var EducationalNote = require('./educational-note');
 
 var LoanOutputRow = React.createClass({
     displayClassNames: function(type) {
@@ -41,15 +42,20 @@ var LoanOutputRow = React.createClass({
             label = this.props.label,
             scenario = this.props.scenario,
             className = this.displayClassNames(resultType),
-            notes = (scenario || {}).outputNotes,
-            educationalNote = (notes  || {})[prop];
+            note,
+            noteHtml;
+                    
+        if (scenario) {
+            note = (this.props.scenario.outputNotes || {})[prop];
+            noteHtml = note ? (<EducationalNote label={label} note={note} type="output"/>) : null;
+            className += note ? ' highlight' : '';
+        }
         
-        className += educationalNote ? ' highlight' : '';
-
         return (
             <tr className={className}>
                 {headingType(prop, resultType, label, scenario)}
                 {loans}
+                <td className="educational-note">{noteHtml}</td>
             </tr>
         );
     }

--- a/src/static/js/modules/loan-comparison/components/next-steps.js
+++ b/src/static/js/modules/loan-comparison/components/next-steps.js
@@ -4,7 +4,7 @@ var ScenarioPicker = require('./scenario-picker');
 var NextSteps = React.createClass({
     render: function () {
         return (
-            <div>
+            <div className="next-steps-container">
                 <div className="content-l content-l__main">
                     <div className="content-l_col content-l_col-1">
                         <h2 className="u-mb-0">Next Steps</h2>

--- a/src/static/js/modules/loan-comparison/components/scenario-button.js
+++ b/src/static/js/modules/loan-comparison/components/scenario-button.js
@@ -3,8 +3,12 @@ var CFButton = require('cf-button');
 
 var ScenarioButton = React.createClass({
     render: function () {
+        var className = 'scenario-picker-button';
+        if (!this.props.scenario) {
+            className += ' u-hide-on-mobile';
+        }
         return (
-            <CFButton config="primary" onClick={this.props.handleChange} className="scenario-picker-button">{this.props.title}</CFButton>
+            <CFButton config="primary" onClick={this.props.handleChange} className={className} disabled={!this.props.scenario}>{this.props.title}</CFButton>
         )
     }
 })

--- a/src/static/js/modules/loan-comparison/components/scenario-picker.js
+++ b/src/static/js/modules/loan-comparison/components/scenario-picker.js
@@ -40,7 +40,7 @@ var ScenarioPicker = React.createClass({
                 <div className="content-l_col scenario-block">
                     <h4 className="h4">Design your own scenarios.</h4>
                     <p className="short-desc">Adjust the factors that affect loan costs to compare two options of your choosing.</p>
-                    <ScenarioButton title="Design my own scenario" handleChange={this.changeScenario}/>
+                    <ScenarioButton title="Design my own scenario" scenario={this.props.scenario} handleChange={this.changeScenario}/>
                 </div>
             </div>
         )

--- a/src/static/js/modules/loan-comparison/mortgage-calculations.js
+++ b/src/static/js/modules/loan-comparison/mortgage-calculations.js
@@ -9,7 +9,7 @@ var INSURANCE_RATE = 0.005;
 var mortgage = {};
 
 mortgage['loan-amount'] = function (loan) {
-    return loan['price'] - loan['downpayment'] || 0;
+    return +loan['price'] - +loan['downpayment'] || 0;
 };
 
 mortgage['discount'] = function (loan) {
@@ -105,7 +105,7 @@ mortgage['monthly-payment'] = function (loan) {
 };
 
 mortgage['closing-costs'] = function (loan) {
-    return loan['downpayment']
+    return +loan['downpayment']
             + loan['discount']
             + loan['processing']
             + loan['third-party-services']
@@ -120,7 +120,7 @@ mortgage['get-cost'] = function (loan) {
         amountBorrowed: positive(loan['loan-amount']),
         rate: loan['interest-rate'],
         totalTerm: loan['loan-term'] * 12,
-        downPayment: loan['downpayment'],
+        downPayment: +loan['downpayment'],
         closingCosts: loan['closing-costs']
     });
 };

--- a/src/static/js/modules/loan-comparison/position-notes.js
+++ b/src/static/js/modules/loan-comparison/position-notes.js
@@ -1,0 +1,96 @@
+var $ = jQuery = require('jquery');
+
+var $allNotes, $outputNotes;
+
+function cacheNotes() {
+    $allNotes = $('.educational-note div');
+    $outputNotes = $allNotes.not('.input');
+}
+
+var positionNotes = function (animating, expandable) {
+    if (!$allNotes) {cacheNotes();}
+    
+    $notes = expandable ? $outputNotes : $allNotes;
+    
+    // Check that we're on desktop
+    if ($notes.css('position') === 'absolute') {
+        var notePositions = [];
+        
+        $notes.each(function (i) {
+            var $this = $(this);
+            var $parent = $this.closest('tr');  
+               
+            // Don't need to position hidden notes (ones in collapsed expandables)
+            if ($parent.is(":visible")) {
+                
+                // Get the parent table row's offset from the top of the page 
+                var parentOffsetTop = $parent.offset().top;
+                                
+                if (expandable) {
+                    var expandableOffsetTop = expandable.offset().top;
+                    // Skip any notes above the triggered expandable
+                    // on an expand/collapse event
+                    if (expandableOffsetTop > parentOffsetTop) {
+                        return;
+                    }
+                    // While animating, hide triggered expandable's child notes
+                    // (except for first row's), and skip repositioning notes
+                    // in or below this expandable until animation stops.
+                    if (animating && expandableOffsetTop <= parentOffsetTop) {
+                        if (expandable.has($this).length > 0 && expandableOffsetTop < parentOffsetTop) {
+                            $this.hide()
+                        }
+                        return;
+                    }
+                }
+                
+                // Get the height of this note
+                var height = $this.height() + 30 // 30 = top + bottom padding;
+                
+                // Get prev note's bottom offset
+                var prevNoteBottom = notePositions[notePositions.length - 1];
+            
+                // If the prev note would be overlapped by this note,
+                // or would not have a 15px vertical separation,
+                // generate an offset value to prevent overlap/add margin
+                var offsetFromPrev = 0;
+                if (i > 0 && parentOffsetTop < (prevNoteBottom + 15)) {
+                    offsetFromPrev = (prevNoteBottom - parentOffsetTop) + 15;
+                }  
+                
+                // Notes are absolutely positioned, so we adjust their position
+                // via top attribute.
+                // Outputs are positioned relative to their parent table row,
+                // so their top attribute is just offsetFromPrev.
+                // Inputs are positioned relative to their parent table, so their top
+                // attribute = (parentOffsetTop - tableOffsetTop) + offsetFromPrev.
+                if ($this.hasClass('input')) {
+                    var tableOffsetTop = $this.closest('table').offset().top;
+                    $this.css({'top': ((parentOffsetTop - tableOffsetTop) + offsetFromPrev) + 'px'}).show();
+                } else {
+                   $this.css({'top': offsetFromPrev + 'px'}).show();
+                }
+                
+                // Store the bottom position of the note for use
+                // in positioning following notes.
+                notePositions.push(parentOffsetTop + offsetFromPrev + height);
+            } 
+        });
+        if (!animating) {
+            // Make sure we're not overlapping the next section,
+            // (but not while we're animating an expandable)
+            var lastNoteOffset = notePositions[notePositions.length - 1];
+            var $nextSection = $('.next-steps-container');
+            var nextSectionOffset = $nextSection.offset().top;
+            // if next section is overlapped, add extra top padding to offset
+            if (nextSectionOffset < lastNoteOffset) {
+                var offsetPadding = lastNoteOffset - nextSectionOffset;
+                $nextSection.css({'padding-top': (offsetPadding + 30) + 'px'})
+            } else {
+                $nextSection.css({'padding-top': '30px'})
+            }
+        }
+    }
+}
+
+module.exports = positionNotes;

--- a/src/static/js/modules/loan-comparison/position-notes.js
+++ b/src/static/js/modules/loan-comparison/position-notes.js
@@ -1,25 +1,17 @@
 var $ = jQuery = require('jquery');
 
-var $allNotes, $outputNotes;
-
-function cacheNotes() {
-    $allNotes = $('.educational-note div');
-    $outputNotes = $allNotes.not('.input');
-}
-
-var positionNotes = function (animating, expandable) {
-    if (!$allNotes) {cacheNotes();}
-    
-    $notes = expandable ? $outputNotes : $allNotes;
+var positionNotes = function (animating, expandable) {    
+    $notes = expandable 
+             ? $('.educational-note div.output') 
+             : $('.educational-note div');
     
     // Check that we're on desktop
-    if ($notes.css('position') === 'absolute') {
+    if ($notes.css('position') == 'absolute') {
         var notePositions = [];
         
         $notes.each(function (i) {
             var $this = $(this);
             var $parent = $this.closest('tr');  
-               
             // Don't need to position hidden notes (ones in collapsed expandables)
             if ($parent.is(":visible")) {
                 

--- a/src/static/js/modules/loan-comparison/stores/loan-store.js
+++ b/src/static/js/modules/loan-comparison/stores/loan-store.js
@@ -111,9 +111,9 @@ function updateLoan(id, prop, val) {
 }
 
 function updateDependencies (loan, prop) {
-    if (!prop || prop === 'price' || prop === 'downpayment') {
+    if (prop === 'price' || prop === 'downpayment') {
         loan['downpayment-percent'] = mortgageCalculations['downpayment-percent'](loan);
-    } else if (prop === 'downpayment-percent') {
+    } else if (!prop || prop === 'downpayment-percent') {
         loan['downpayment'] = mortgageCalculations['downpayment'](loan);        
     }
     return loan;

--- a/src/static/js/modules/loan-comparison/stores/loan-store.js
+++ b/src/static/js/modules/loan-comparison/stores/loan-store.js
@@ -146,7 +146,7 @@ function processRatesResults(results) {
         }
     }
     rates = rates.sort();
-    var medianRate = common.median(rates) || 0;
+    var medianRate = common.median(totalRates) || 0;
     var processedRates = $.map(rates, function( rate, i ) {
         return {val: Number(rate), label: rate + '%'};
     });


### PR DESCRIPTION
### Changes
- Scope loan input table styling more specifically to `#loan-input-table` (instead of `table.unstyled`)
- Fix typo in median interest rate calculation (should get median from `totalRates` instead of `rates`)
- Updates to loan input table header styling

### Additions
- Add educational notes & first pass at styling/positioning them on desktop
- New content for input/output tooltips

### Screenshots
![screen shot 2015-06-08 at 1 43 05 am](https://cloud.githubusercontent.com/assets/778171/8028650/fb442888-0d7f-11e5-8bca-b9ee1a3ab7a9.png)

### Review
@cfarm 
@huetingj 
@stephanieosan 


