### PR TITLE
Fix broken browser tests

### DIFF
--- a/test/browser_testing/features/navigation.feature
+++ b/test/browser_testing/features/navigation.feature
@@ -20,8 +20,6 @@ Examples:
   | compare-learn-link         | Know the Process                    | process/compare/                            |
   | decide-header-link         | Know the Process                    | process/decide/                            |
   | decide-learn-link         | Know the Process                    | process/decide/                            |
-  | maintain-header-link         | Know the Process                    | process/maintain/                            |
-  | maintain-learn-link         | Know the Process                    | process/maintain/                            |
 
 
 @smoke_testing @landing_page


### PR DESCRIPTION
Reference: https://github.com/cfpb/owning-a-home/pull/452
### Removes
- Removes reference to test maintain pages in browser tests

### Review
@cfarm @virginiacc 