### PR TITLE
subtract down payment from closing costs for overall-loan-cost object

### DIFF
--- a/src/static/js/modules/loan-comparison/mortgage-calculations.js
+++ b/src/static/js/modules/loan-comparison/mortgage-calculations.js
@@ -121,7 +121,7 @@ mortgage['get-cost'] = function (loan) {
         rate: loan['interest-rate'],
         totalTerm: loan['loan-term'] * 12,
         downPayment: +loan['downpayment'],
-        closingCosts: loan['closing-costs']
+        closingCosts: +loan['closing-costs'] - +loan['downpayment']
     });
 };
 


### PR DESCRIPTION
The overall-loan-cost module takes properties for closing costs and down payment separately, therefore down payment should not be included in the closing-costs value. This bug causes the overall costs to increase if your down payment is bigger, which is wrong.

## Changes

- calculations object for the overall-loan-cost module now subtracts down payment from closing-costs since *our* closing-costs property includes dp, but the module needs them passed separately

## Testing

- We need to write tests to make sure this is working as expected, on the docket for 6/9

## Review

do not review until you see tests here