### PR TITLE
Change search_with_url_parameters to search

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -13,7 +13,7 @@
 {% set docsource = active_phase.hit_dict['_source'] %}
 {% set id_str = docsource['id']|string %}
 {% set filter = 'parent:' + id_str  %}
-{% set steps = query.search_with_url_arguments(size=100,q=filter) %}
+{% set steps = query.search(size=100,q=filter) %}
 
 <main class="know-the-process wrapper" id="main" role="main">
   <div>


### PR DESCRIPTION
This is a change necessary for a function's name change in sheer! [That sheer pull request is here](https://github.com/cfpb/sheer/pull/108).

There were two things that needed to change about that search function:
1. The name needed changing.
2. The function would always pull in URL parameters into the queries and apply them. 

Number 2 is great when you want the URL parameters for a filter query, but not so great if you have other queries that do not want those parameters because it will apply them indiscriminately. If you run into this problem, adding the `use_url_arguments=False` will solve that problem. 

The function does not need this flag to be set because, by default, it is set to True!

@fna  