### PR TITLE
Exclude vendor js folders for coverage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -392,6 +392,7 @@ module.exports = function(grunt) {
           harmony: true,
           coverageFolder: 'test/coverage',
           coverage: true,
+          excludes: ['src/static/vendor/**/*'],
           check: {
             lines: 50,
             statements: 50


### PR DESCRIPTION
### Additions

* Add Vendor JS folders to be excluded during testing coverage

### Reviews
@cfarm @virginiacc 