### PR TITLE
Landing page tests: remove trailing slash in pdf link

### DIFF
--- a/test/browser_testing/features/navigation.feature
+++ b/test/browser_testing/features/navigation.feature
@@ -38,5 +38,5 @@ Examples:
   | Learn how the CFPB is protecting mortgage borrowers | Know Before You Owe                | /knowbeforeyouowe/ |
   | We can help | Mortgage help                | /mortgagehelp/ |
   | Get videos, compliance guides, and other resources | Regulatory implementation                | /regulatory-implementation/ |
-   | Your home loan toolkit: a step-by-step guide | Mortgage booklet                | /http://www.consumerfinance.gov/f/201503_cfpb_your-home-loan-toolkit-web.pdf/ |
+   | Your home loan toolkit: a step-by-step guide | Mortgage booklet                | /http://www.consumerfinance.gov/f/201503_cfpb_your-home-loan-toolkit-web.pdf |
   | More mortgage-related guides | Consumer Financial Protection Bureau publications                | http://promotions.usa.gov/cfpbpubs.html#mortgages |


### PR DESCRIPTION
### Changes
- Remove trailing slash from loan toolkit pdf link in test data