### PR TITLE
Loan comparison: auto api calls -- do not merge

### DIFF
--- a/src/static/js/modules/loan-comparison/stores/loan-store.js
+++ b/src/static/js/modules/loan-comparison/stores/loan-store.js
@@ -99,7 +99,6 @@ var LoanStore = assign({}, EventEmitter.prototype, {
         this.validateLoan(loan);
         this.updateLoanCalculatedProperties(loan, rateChange);
         if (!rateChange) {
-            console.log('not rate change');
             this.fetchLoanData(id);
         }
     },

--- a/src/static/js/modules/loan-comparison/stores/loan-store.js
+++ b/src/static/js/modules/loan-comparison/stores/loan-store.js
@@ -224,6 +224,7 @@ var LoanStore = assign({}, EventEmitter.prototype, {
         var rates = this.processRatesData(data);
         loan['rates'] = rates.vals;
         loan['interest-rate'] = rates.median;
+        LoanStore.updateLoanCalculatedProperties(loan, true);
     },
     
     /**

--- a/src/static/js/modules/loan-comparison/stores/loan-store.js
+++ b/src/static/js/modules/loan-comparison/stores/loan-store.js
@@ -93,14 +93,13 @@ var LoanStore = assign({}, EventEmitter.prototype, {
         
         if (prop) {
             loan[prop] = val || null;
-            loan['edited'] = !rateChange;
         }
         
         this.updateLoanDependencies(loan, prop);
         this.validateLoan(loan);
         this.updateLoanCalculatedProperties(loan, rateChange);
-
-        if (loan['rate-request']) {
+        if (!rateChange) {
+            console.log('not rate change');
             this.fetchLoanData(id);
         }
     },
@@ -226,7 +225,6 @@ var LoanStore = assign({}, EventEmitter.prototype, {
         var rates = this.processRatesData(data);
         loan['rates'] = rates.vals;
         loan['interest-rate'] = rates.median;
-        loan['edited'] = false;
     },
     
     /**


### PR DESCRIPTION
### Changes
- Automatically call api for new rates when loan is changed

### Notes
- Do not merge -- this is just for testing purposes
- This is a quick test, so it doesn't have a loading state for the outputs. The rate input still switches out for a loading icon while the api is being queried.

### Testing
- Check out locally.
- Change a value on a loan. Wait for the interest rate dropdown & outputs to automatically update with new data from the api. 

### Review
@cfarm @stephanieosan @sonnakim