### PR TITLE
Form Explainer - Fix illustration size across screens

### DIFF
--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -20,7 +20,7 @@
 
       <div class="col-4">
         <img src="../static/img/ill-form-explainer-closing-disc.png" alt="" class="illustration">
-      </div><!-- /.col-4.illustration -->
+      </div><!-- /.col-4 -->
 
       {# Import the form explainer macros #}
       {% import "form-explainer.html" as form_explainer %}

--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -18,8 +18,8 @@
         
       </div><!-- /.col-8.page-intro -->
 
-      <div class="col-4 illustration">
-        <img src="../static/img/ill-form-explainer-closing-disc.png" alt="">
+      <div class="col-4">
+        <img src="../static/img/ill-form-explainer-closing-disc.png" alt="" class="illustration">
       </div><!-- /.col-4.illustration -->
 
       {# Import the form explainer macros #}

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -16,9 +16,9 @@
         <p class="lead">When you receive a Loan Estimate, it should reflect a particular loan you discussed with a lender. Check to see that everything matches your expectations. If something looks different from what you expected, ask why. This tool will help you review your Loan Estimate and get definitions for unfamiliar terms.</p>
       </div><!-- /.page-intro -->
 
-      <div class="col-4 illustration">
-        <img src="../static/img/ill-form-explainer-loan-est.png" alt="">
-      </div><!-- /.col-4.illustration -->
+      <div class="col-4">
+        <img src="../static/img/ill-form-explainer-loan-est.png" alt="" class="illustration">
+      </div><!-- /.col-4 -->
 
       {# Import the form explainer macros #}
       {% import "form-explainer.html" as form_explainer %}

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -4,11 +4,18 @@
 
 .form-explainer {
     .webfont-regular();
+
+    .illustration {
+        padding-top: 1em;
+        width: 200px;
+        margin: 0 auto;
+        display: block;
+        .respond-to-max(719px, {
+            display: none;
+        });
+    }
 }
 
-.illustration {
-  padding: 1em 4.5em 0 4.5em;
-}
 
 .image-map {
     display: block;


### PR DESCRIPTION
### Changes
* Illustrations on Closing Disclosure and Loan Estimate are now 200px until it can no longer fit the screen, which is when the screen is about 720px
* Illustrations will disappear if it is less than 720px

### Screenshots

I only included screenshots for closing disclosure.  Loan Estimate looks the same, but if you like to see them too, I can as well put them up:

**Desktop**:
<img width="1440" alt="screen shot 2015-07-14 at 6 22 13 pm" src="https://cloud.githubusercontent.com/assets/2673022/8686565/8f0f9420-2a55-11e5-9f13-e9ad20df81cc.png">

**Medium-sized screen**:
<img width="933" alt="screen shot 2015-07-14 at 6 22 38 pm" src="https://cloud.githubusercontent.com/assets/2673022/8686568/95be5b30-2a55-11e5-9856-00109d3ec997.png">
<img width="724" alt="screen shot 2015-07-14 at 6 23 08 pm" src="https://cloud.githubusercontent.com/assets/2673022/8686570/981ad426-2a55-11e5-92a7-f032136a80a9.png">

*Smaller than 720px*:
<img width="714" alt="screen shot 2015-07-14 at 6 23 23 pm" src="https://cloud.githubusercontent.com/assets/2673022/8686577/9df32baa-2a55-11e5-9c71-9943bc2ea3cd.png">

**Mobile**:
<img width="400" alt="screen shot 2015-07-14 at 6 23 34 pm" src="https://cloud.githubusercontent.com/assets/2673022/8686586/a50aab8e-2a55-11e5-9ee5-09bc9b3cd517.png">

### Reviews:
@stephanieosan @huetingj @cfarm @virginiacc 