### PR TITLE
Form explainer 'new' tag

### DIFF
--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -131,64 +131,53 @@
 
 {% macro term( item, index, page_num ) %}
 {#- Some terms are not expandable -#}
-{% if item.definition == '' %}
-  <div class="expandable expandable__padded
-              expandable__form-explainer
-              expandable__form-explainer-{{ item.category }}"
-       id="{{ 'page-' + page_num|string + '-' + item.category + '-' + item.id }}"
-       tabindex="0">
-    <span class="expandable_header">
-      <span class="expandable_label">
-          <span class="expandable_category expandable_category__{{ item.category }}">
-            <span class="u-visually-hidden">{{ item.category }}</span>
-          </span>
-          {{ item.term }}
-          {% if item.new -%}
-            <strong class="item__new">  
-              <span class="cf-icon cf-icon-information"></span>
-              New
-            </strong>
-          {%- endif %}
+<div class="expandable expandable__padded
+            expandable__form-explainer
+            expandable__form-explainer-{{ item.category }}"
+     id="{{ 'page-' + page_num|string + '-' + item.category + '-' + item.id }}"
+     {% if item.definition == '' %}
+     tabindex="0"{% endif %}>
+  {% if item.definition == '' %}
+  <span class="expandable_header">
+    <span class="expandable_label">
+  {% else %}
+  <button class="expandable_header expandable_target" tabindex="0">
+    <span class="expandable_header-left expandable_label">
+  {% endif %}
+      <span class="expandable_category expandable_category__{{ item.category }}">
+        <span class="u-visually-hidden">{{ item.category }}</span>
+      </span>
+      {{ item.term }}
+      {% if item.new -%}
+        <strong class="item__new">  
+          <span class="cf-icon cf-icon-information"></span>
+          New
+        </strong>
+      {%- endif %}
+  {% if item.definition == '' %}
+    </span>
+  </span>
+  {% else %}
+  </span>
+    <span class="expandable_header-right expandable_link">
+      <span class="expandable_cue-open">
+        <span class="u-visually-hidden">Show</span>
+        <span class="cf-icon cf-icon-plus"></span>
+      </span>
+      <span class="expandable_cue-close">
+        <span class="u-visually-hidden">Hide</span>
+        <span class="cf-icon cf-icon-minus"></span>
       </span>
     </span>
+  </button>
+  <div class="expandable_content u-stick" tabindex="0">
+    {{ item.definition|safe }}
+    {% if item.highlight -%}
+      <img class="u-stick_bottom" src="{{ item.highlight }}" alt="">
+    {%- endif %}
   </div>
-{% else %}
-  <div class="expandable expandable__padded
-              expandable__form-explainer
-              expandable__form-explainer-{{ item.category }}"
-       id="{{ 'page-' + page_num|string + '-' + item.category + '-' + item.id }}">
-    <button class="expandable_header expandable_target" tabindex="0">
-      <span class="expandable_header-left expandable_label">
-          <span class="expandable_category expandable_category__{{ item.category }}">
-            <span class="u-visually-hidden">{{ item.category }}</span>
-          </span>
-          {{ item.term }}
-          {% if item.new -%}
-            <strong class="item__new">  
-              <span class="cf-icon cf-icon-information"></span>
-              New
-            </strong>
-          {%- endif %}
-      </span>
-      <span class="expandable_header-right expandable_link">
-        <span class="expandable_cue-open">
-          <span class="u-visually-hidden">Show</span>
-          <span class="cf-icon cf-icon-plus"></span>
-        </span>
-        <span class="expandable_cue-close">
-          <span class="u-visually-hidden">Hide</span>
-          <span class="cf-icon cf-icon-minus"></span>
-        </span>
-      </span>
-    </button>
-    <div class="expandable_content u-stick" tabindex="0">
-      {{ item.definition|safe }}
-      {% if item.highlight -%}
-        <img class="u-stick_bottom" src="{{ item.highlight }}" alt="">
-      {%- endif %}
-    </div>
-  </div>
-{% endif %}
+  {% endif %}
+</div>
 {% endmacro %}
 
 

--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -149,10 +149,7 @@
       </span>
       {{ item.term }}
       {% if item.new -%}
-        <strong class="item__new">  
-          <span class="cf-icon cf-icon-information"></span>
-          New
-        </strong>
+        <span class="micro-copy term-tag"><em>New</em></span>
       {%- endif %}
   {% if item.definition == '' %}
     </span>

--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -143,6 +143,12 @@
             <span class="u-visually-hidden">{{ item.category }}</span>
           </span>
           {{ item.term }}
+          {% if item.new -%}
+            <strong class="item__new">  
+              <span class="cf-icon cf-icon-information"></span>
+              New
+            </strong>
+          {%- endif %}
       </span>
     </span>
   </div>
@@ -157,6 +163,12 @@
             <span class="u-visually-hidden">{{ item.category }}</span>
           </span>
           {{ item.term }}
+          {% if item.new -%}
+            <strong class="item__new">  
+              <span class="cf-icon cf-icon-information"></span>
+              New
+            </strong>
+          {%- endif %}
       </span>
       <span class="expandable_header-right expandable_link">
         <span class="expandable_cue-open">

--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -148,8 +148,8 @@
         <span class="u-visually-hidden">{{ item.category }}</span>
       </span>
       {{ item.term }}
-      {% if item.new -%}
-        <span class="micro-copy term-tag"><em>New</em></span>
+      {% if item.tag -%}
+        <span class="micro-copy term-tag"><em>{{ item.tag }}</em></span>
       {%- endif %}
   {% if item.definition == '' %}
     </span>

--- a/src/loan-estimate/loan-estimate-1.html
+++ b/src/loan-estimate/loan-estimate-1.html
@@ -11,7 +11,8 @@
         "left": "16.17%",
         "top": "15.02%",
         "width": "21.56%",
-        "height": "4.50%"
+        "height": "4.50%",
+        "new": true
     },
     {
         "term": "Check loan terms, purpose, product, and type",

--- a/src/loan-estimate/loan-estimate-1.html
+++ b/src/loan-estimate/loan-estimate-1.html
@@ -12,7 +12,7 @@
         "top": "15.02%",
         "width": "21.56%",
         "height": "4.50%",
-        "new": true
+        "tag": "new"
     },
     {
         "term": "Check loan terms, purpose, product, and type",

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -65,6 +65,7 @@
 }
 
 .expandable__form-explainer {
+    position: relative;
     margin: 0 0 unit(3px / @base-font-size-px, em);
     transition: transform 100ms ease-out;
     &.has-attention {
@@ -114,22 +115,6 @@
     }
 }
 
-.expandable__form-explainer-alerts {
-    &,
-    &:hover,
-    &.expandable__expanded,
-    &.has-attention {
-        background: @redorange-20;
-    }
-    .expandable_category:before {
-        content: "\e103"; // .cf-icon-error-round
-        color: @redorange-80;
-    }
-    .expandable_content:before {
-        background: @redorange-50;
-    }
-}
-
 .expandable__form-explainer-definitions {
     &,
     &:hover,
@@ -145,6 +130,18 @@
         background: @navy-50;
     }
 }
+
+    // "NEW" tag in expandables/terms content
+    .term-tag {
+        padding: 2px 5px;
+        position: absolute;
+        top: 0;
+        left: 0;
+        background: @gray;
+        color: @white;
+        font-size: 12px;
+        text-transform: uppercase;
+    }
 
 .explain {
     margin: 0 auto unit(60px / @base-font-size-px, em);

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -140,6 +140,7 @@
         background: fade(@darkgray, 75%);
         color: @white;
         font-size: 11px;
+        text-transform: capitalize;
     }
 
 .explain {

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -137,10 +137,9 @@
         position: absolute;
         top: 0;
         left: 0;
-        background: @gray;
+        background: fade(@darkgray, 75%);
         color: @white;
-        font-size: 12px;
-        text-transform: uppercase;
+        font-size: 11px;
     }
 
 .explain {


### PR DESCRIPTION
Add 'new' tag element to the form explainer content boxes.

## Additions

- Logic for new tags
- 'new' property on loan estimate's first content box - as example til we have the actual content that needs these.

## Removals

- alert tab styles - we removed the alert tabs from the design so these are no longer needed.

## Changes

- refactored the conditionals for the term (aka content box) so that there is less duplicate stuff

## Testing

- go to [http://localhost:7000/loan-estimate/](http://localhost:7000/loan-estimate/) to see the New tag output on the first content box.
- CMD+F5 to use voiceover and tab through the page to hear the tag read aloud (it's after the content title, to give the user context).

## Review

- @sonnakim 
- @virginiacc 

## Preview

### Small screen
![screen shot 2015-07-15 at 1 44 48 pm](https://cloud.githubusercontent.com/assets/702526/8705554/4ecba702-2af8-11e5-9a27-02b6d4679cd0.png)

### Large screen
![screen shot 2015-07-15 at 1 44 56 pm](https://cloud.githubusercontent.com/assets/702526/8705559/573d60ec-2af8-11e5-93c7-c13436e9df0a.png)
