### PR TITLE
Make Show and Hide visible in Loan Comparison

### DIFF
--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -1049,3 +1049,9 @@ table.unstyled {
 .help-text {
   display: none;
 }
+
+.u-hide-med-size-mobile {
+  .respond-to-max(1200px, {
+    display: none;
+  });
+}

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -486,15 +486,12 @@
     .grid_column(1,2);
     .respond-to-min(@tablet-min, {
       .grid_column(1,3);
+      padding-right: 70px;
+    });
+    .respond-to-min(1000px, {
       &.lc-primary-result {
         vertical-align: bottom;
       }
-    });
-    .respond-to-min(1000px, {
-      padding-right: @grid_gutter-width;
-    });
-    .respond-to-min(1200px, {
-      padding-right: @grid_gutter-width*2;
     });
   }
 }
@@ -599,10 +596,14 @@
     .expandable__table {      
       .expandable_header-right {
         position: absolute;
+        top: @grid_gutter-width/2;
         right: @grid_gutter-width/2;
+        font-size: 14px;
         .respond-to-min(@tablet-min, {
-          top: @grid_gutter-width/2;
-          font-size: 22px;
+          top: 18px;
+        });
+        .respond-to-min(1000px, {
+          top: 22px;
         });
       }
     }
@@ -1050,8 +1051,3 @@ table.unstyled {
   display: none;
 }
 
-.u-hide-med-size-mobile {
-  .respond-to-max(1200px, {
-    display: none;
-  });
-}

--- a/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
@@ -95,11 +95,11 @@ var LoanOutputRowPrimaryHeading = React.createClass({
                 </h4>
                 <span className="expandable_header-right expandable_link">
                     <span className="expandable_cue-open">
-                        <span className="u-hide-med-size-mobile">Show </span>
+                        <span>Show </span>
                         <span className="cf-icon cf-icon-plus-round"></span>
                     </span>
                     <span className="expandable_cue-close">
-                        <span className="u-hide-med-size-mobile">Hide </span>
+                        <span>Hide </span>
                         <span className="cf-icon cf-icon-minus-round"></span>
                     </span>
                 </span>

--- a/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
@@ -95,11 +95,11 @@ var LoanOutputRowPrimaryHeading = React.createClass({
                 </h4>
                 <span className="expandable_header-right expandable_link">
                     <span className="expandable_cue-open">
-                        <span className="u-visually-hidden">Show</span>
+                        <span>Show</span>
                         <span className="cf-icon cf-icon-plus-round"></span>
                     </span>
                     <span className="expandable_cue-close">
-                        <span className="u-visually-hidden">Hide</span>
+                        <span>Hide</span>
                         <span className="cf-icon cf-icon-minus-round"></span>
                     </span>
                 </span>

--- a/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
+++ b/src/static/js/modules/loan-comparison/components/loan-output-table-row.js
@@ -95,11 +95,11 @@ var LoanOutputRowPrimaryHeading = React.createClass({
                 </h4>
                 <span className="expandable_header-right expandable_link">
                     <span className="expandable_cue-open">
-                        <span>Show</span>
+                        <span className="u-hide-med-size-mobile">Show </span>
                         <span className="cf-icon cf-icon-plus-round"></span>
                     </span>
                     <span className="expandable_cue-close">
-                        <span>Hide</span>
+                        <span className="u-hide-med-size-mobile">Hide </span>
                         <span className="cf-icon cf-icon-minus-round"></span>
                     </span>
                 </span>


### PR DESCRIPTION
### Deletions
* Remove the class to hide show/hide text

### Screenshots
Designers @sonnakim @stephanieosan @huetingj Please advise how you want this to look.

Desktop:
<img width="1438" alt="screen shot 2015-07-16 at 5 23 39 pm" src="https://cloud.githubusercontent.com/assets/2673022/8735583/0afa80be-2be0-11e5-8ac4-5d03dc9f47de.png">

Medium-sized:
<img width="992" alt="screen shot 2015-07-16 at 5 23 53 pm" src="https://cloud.githubusercontent.com/assets/2673022/8735586/0e32ba26-2be0-11e5-82fa-77516ab767e9.png">

Mobile:
<img width="400" alt="screen shot 2015-07-16 at 5 24 42 pm" src="https://cloud.githubusercontent.com/assets/2673022/8735590/14282d76-2be0-11e5-96a3-d4d959af2a69.png">

### Reviews:
@sonnakim @stephanieosan @huetingj 