### PR TITLE
Form explainer: IE8 highlighting

### DIFF
--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -46,6 +46,7 @@
     & {
         background: rgba(255,147,27,0.2);
     }
+    
     &:hover,
     &:focus,
     &.has-attention  {
@@ -56,10 +57,19 @@
         outline-offset: 1px;
     }
 }
+
+.lt-ie9 .image-map_overlay__checklist {
+    background:none;
+    -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
+    filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
+    zoom: 1;
+}
+
 .image-map_overlay__definitions {
     & {
         background: rgba(0,45,114,0.2);
     }
+    
     &:hover,
     &:focus,
     &.has-attention  {
@@ -69,6 +79,13 @@
         outline: 1px dotted @navy;
         outline-offset: 1px;
     }
+}
+
+.lt-ie9 .image-map_overlay__definitions {
+    background:none;
+    -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33002D72,endColorstr=#33002D72)";
+    filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33002D72,endColorstr=#33002D72)";
+    zoom: 1;
 }
 
 .expandable__form-explainer {


### PR DESCRIPTION
### Additions
- Add filters to apply transparent background color to highlight links on form explainer images in IE8

### Preview
<img width="1062" alt="screen shot 2015-07-20 at 10 57 35 am" src="https://cloud.githubusercontent.com/assets/778171/8778913/7359b54e-2ece-11e5-84e8-11e7f284e243.png">

### Review
@cfarm 
@stephanieosan or @huetingj or @sonnakim 