### PR TITLE
Form explainer: new titles

### DIFF
--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -24,13 +24,13 @@
       <li class="tab-list active-tab">
         <button class="tab-link tab-link__checklist" data-target="checklist" tabindex="0">
           <span class="cf-icon cf-icon-approved-round"></span>
-          <span class="tab-label">Checklist</span>
+          <span class="tab-label">Check details</span>
         </button>
       </li>
       <li class="tab-list">
         <button class="tab-link tab-link__definitions" data-target="definitions" tabindex="0">
           <span class="cf-icon cf-icon-help-round"></span>
-          <span class="tab-label">Definitions</span>
+          <span class="tab-label">Get definitions</span>
         </button>
       </li>
     </ul>


### PR DESCRIPTION
### Changes
- Change form explainer titles

### Preview
<img width="1046" alt="screen shot 2015-07-20 at 11 16 30 am" src="https://cloud.githubusercontent.com/assets/778171/8779344/fd1196b0-2ed0-11e5-9a2b-3d3a3f05289e.png">

### Review
- @cfarm @stephanieosan 

### Notes
- This is just the titles; the messaging when there are no items of a given type hasn't been changed yet.