### PR TITLE
Form explainer: accordion behaviour & reduced padding

### DIFF
--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -45,7 +45,9 @@
         </div>
       </div>
       <figcaption class="terms explain_terms">
-        {{ render_terms( page.terms, loop.index ) }}
+          <div class="expandable-group expandable-group__form-explainer" data-accordion="true">
+              {{ render_terms( page.terms, loop.index ) }}
+          </div>
       </figcaption>
     </figure>
     {% endfor %}

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -88,7 +88,8 @@
     zoom: 1;
 }
 
-.expandable__form-explainer {
+.expandable-group .expandable__form-explainer {
+    border-bottom: none;
     margin: 0 0 unit(3px / @base-font-size-px, em);
     transition: transform 100ms ease-out;
     &.has-attention {
@@ -98,11 +99,17 @@
         max-width: 90%;
     }
     .expandable_header {
-        // Eyeballed to 30px when including line-height
-        padding: unit((@grid_gutter-width - 3) / @base-font-size-px, em)
+        padding: unit((@grid_gutter-width/2) / @base-font-size-px, em)
                  unit(@grid_gutter-width / @base-font-size-px, em)
-                 unit((@grid_gutter-width - 4) / @base-font-size-px, em);
+                 unit((@grid_gutter-width/2) / @base-font-size-px, em);
+        border-bottom: none;
     }
+    
+    .expandable_label {
+      font-size: unit(@base-font-size-px / 16 * 100, %);
+      line-height: @base-line-height;
+    }
+    
     .expandable_link {
         color: @gray;
     }
@@ -122,7 +129,7 @@
     }
 }
 
-.expandable__form-explainer-checklist {
+.expandable-group .expandable__form-explainer-checklist {
     &,
     &:hover,
     &.expandable__expanded,
@@ -138,7 +145,7 @@
     }
 }
 
-.expandable__form-explainer-alerts {
+.expandable-group .expandable__form-explainer-alerts {
     &,
     &:hover,
     &.expandable__expanded,
@@ -154,7 +161,7 @@
     }
 }
 
-.expandable__form-explainer-definitions {
+.expandable-group .expandable__form-explainer-definitions {
     &,
     &:hover,
     &.expandable__expanded,


### PR DESCRIPTION
### Changes
- Reduce vertical padding on form explainer expandables
- Add accordion behaviour to form explainer expandables so only one will be open at a time

### Preview
<img width="1046" alt="screen shot 2015-07-22 at 5 44 00 pm" src="https://cloud.githubusercontent.com/assets/778171/8838325/d3b1cf86-3099-11e5-9049-9dc4c65b1c08.png">

### Review
- @stephanieosan 
- @fna or @cfarm or @amymok 