### PR TITLE
Form Explainer: add definitions & fix checklist highlight widths

### DIFF
--- a/src/closing-disclosure/closing-disclosure-1.html
+++ b/src/closing-disclosure/closing-disclosure-1.html
@@ -58,9 +58,9 @@
         "definition": "<p>This feature is risky. If your loan includes one, learn more and ask your lender about your other options.</p><p><a href=\"http://www.consumerfinance.gov/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\">Learn more about prepayment penalties</a></p>",
         "id": "prepayment-penalty",
         "category": "checklist",
-        "left": "29.50%",
+        "left": "5.96%",
         "top": "40.13%",
-        "width": "64.68%",
+        "width": "88.23%",
         "height": "6.25%"
     },
     {
@@ -68,9 +68,9 @@
         "definition": "<p>This feature is risky. If your loan includes one, learn more and ask your lender about your other options.</p> <p><a href=\"http://www.consumerfinance.gov/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more about balloon payments</a></p>",
         "id": "balloon-payment",
         "category": "checklist",
-        "left": "29.50%",
+        "left": "5.96%",
         "top": "46.38%",
-        "width": "64.68%",
+        "width": "88.23%",
         "height": "2.74%"
     },
     {
@@ -139,9 +139,9 @@
         "definition": "<p>Make sure you can comfortably afford to pay this amount every month. If this number doesn't reflect what you were expecting, ask your lender why it has changed.</p>",
         "id": "estimated-total-monthly",
         "category": "checklist",
-        "left": "29.50%",
+        "left": "5.96%",
         "top": "66.78%",
-        "width": "64.68%",
+        "width": "88.23%",
         "height": "3.62%"
     },
     {
@@ -179,9 +179,9 @@
         "definition": "<p>If there are significant changes, ask your lender to explain why.</p>",
         "id": "closing-costs",
         "category": "checklist",
-        "left": "29.50%",
+        "left": "5.96%",
         "top": "85.31%",
-        "width": "64.68%",
+        "width": "88.23%",
         "height": "4.50%"
     },
     {
@@ -189,9 +189,9 @@
         "definition": "<p>If not, ask your lender to explain why.</p>",
         "id": "cash-close",
         "category": "checklist",
-        "left": "29.50%",
+        "left": "5.96%",
         "top": "89.80%",
-        "width": "64.68%",
+        "width": "88.23%",
         "height": "4.61%"
     }
 ]

--- a/src/loan-estimate/loan-estimate-1.html
+++ b/src/loan-estimate/loan-estimate-1.html
@@ -50,7 +50,7 @@
         "category": "checklist",
         "left": "6.95%",
         "top": "31.25%",
-        "width": "23.40%",
+        "width": "86.24%",
         "height": "3.51%"
     },
     {
@@ -88,9 +88,9 @@
         "definition": "<p>This feature is risky. If your loan includes one, learn more and ask your lender or broker about your other options.</p><p><a href=\"http://www.consumerfinance.gov/askcfpb/1957/what-is-a-prepayment-penalty.html\"target=\"_blank\">Learn more</a></p>",
         "id": "prepayment-penalty",
         "category": "checklist",
-        "left": "30.50%",
+        "left": "6.95%",
         "top": "41.67%",
-        "width": "62.55%",
+        "width": "86.24%",
         "height": "6.14%"
     },
     {
@@ -98,9 +98,9 @@
         "definition": "<p>This feature is risky. If your loan includes one, ask your lender about your other options.</p><p><a href=\"http://www.consumerfinance.gov/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more about balloon payments</a></p>",
         "id": "balloon-payment",
         "category": "checklist",
-        "left": "30.50%",
+        "left": "6.95%",
         "top": "47.92%",
-        "width": "62.55%",
+        "width": "86.24%",
         "height": "2.74%"
     },
     {
@@ -148,9 +148,9 @@
         "definition": "<p>Are you comfortable spending this much on housing each month? A good guideline is to spend no more than 28 percent of your monthly pre-tax income on housing.</p>",
         "id": "estimated-total-monthly-payment",
         "category": "checklist",
-        "left": "30.50%",
+        "left": "6.95%",
         "top": "67.43%",
-        "width": "62.55%",
+        "width": "86.24%",
         "height": "3.51%"
     },
     {
@@ -188,9 +188,9 @@
         "definition": "",
         "id": "estimated-cash-to-close",
         "category": "checklist",
-        "left": "30.50%",
+        "left": "6.95%",
         "top": "89.80%",
-        "width": "62.55%",
+        "width": "86.24%",
         "height": "4.39%"
     }
 ]

--- a/src/loan-estimate/loan-estimate-3.html
+++ b/src/loan-estimate/loan-estimate-3.html
@@ -3,6 +3,36 @@
 "img": url_for('static', filename='img/loan-estimate-H24B-3.gif'),
 'terms':
 [
+    {
+        "term": "Annual Percentage Rate (APR)",
+        "definition": "<p><a href=\"http://www.consumerfinance.gov/askcfpb/135/what-is-the-difference-between-a-mortgage-interest-rate-and-an-apr.html\" target=\"_blank\">Learn more about how your APR is different from your interest rate</a></p>",
+        "id": "apr",
+        "category": "definitions",
+        "left": "6.95%",
+        "top": "32.87%",
+        "width": "23.4%",
+        "height": "3.10%"
+    },
+    {
+        "term": "Total Interest Percentage (TIP)",
+        "definition": "<p>Learn more about what this number means</p>",
+        "id": "tip",
+        "category": "definitions",
+        "left": "6.95%",
+        "top": "35.98%",
+        "width": "23.4%",
+        "height": "4.3%"
+    },
+    {
+        "term": "Appraisal",
+        "definition": "<p><a href=\"http://www.consumerfinance.gov/askcfpb/167/what-is-an-appraisal.html\" target=\"_blank\">Learn more about what to expect from your appraisal</a></p>",
+        "id": "appraisal",
+        "category": "definitions",
+        "left": "6.95%",
+        "top": "46.16%",
+        "width": "20%",
+        "height": "5.7%"
+    }
 ]
 
 } %}


### PR DESCRIPTION
### Additions
- Add definitions to page 3 of Loan Estimate

### Changes
- Make highlights full width on first pages of Loan Estimate & Closing Disclosure form explainers

### Preview
**New definitions**, Loan Estimate, page 3:

<img width="1073" alt="screen shot 2015-07-23 at 12 09 50 pm" src="https://cloud.githubusercontent.com/assets/778171/8855805/2506ad2a-3135-11e5-99e9-f38ee6267e90.png">

**Full width highlights:**
Loan Estimate, page 1:

<img width="403" alt="screen shot 2015-07-23 at 12 09 25 pm" src="https://cloud.githubusercontent.com/assets/778171/8855779/0e90bcac-3135-11e5-8f57-3bca1bba48d2.png">

Closing Disclosure, page 1:

<img width="410" alt="screen shot 2015-07-23 at 12 11 12 pm" src="https://cloud.githubusercontent.com/assets/778171/8855792/1c403620-3135-11e5-939b-c367c1deb37c.png">

### Notes
- The TIP definition text says `Learn more about what this number means`, but doesn't link to anything
<img width="458" alt="screen shot 2015-07-23 at 12 25 38 pm" src="https://cloud.githubusercontent.com/assets/778171/8855966/ff487d6a-3135-11e5-9257-367faea4947e.png">

### Review
@stephanieosan or @fna or @cfarm or @amymok 