### PR TITLE
Form Explainer - Using Darker Color for Hover and Select

### DIFF
--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -51,6 +51,7 @@
     &:focus,
     &.has-attention  {
         border-color: @gold-80;
+        background: rgba(255,147,27,0.5);
     }
     &:focus {
         outline: 1px dotted @gold;
@@ -130,12 +131,25 @@
 }
 
 .expandable-group .expandable__form-explainer-checklist {
-    &,
-    &:hover,
-    &.expandable__expanded,
-    &.has-attention {
+    & {
         background: @gold-20;
     }
+    &:hover,
+    &.has-attention {
+        .expandable_header {
+            background: rgb(255,177,73);
+        }
+        &.expandable__expanded {
+
+            border: 3px solid;
+            border-color: rgb(255,177,73);
+        } 
+        .expandable_category:before {
+            content: "\e101"; // .cf-icon-approved-round
+            color: @black;
+        }              
+    }
+
     .expandable_category:before {
         content: "\e101"; // .cf-icon-approved-round
         color: @gold-80;

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -75,6 +75,7 @@
     &:focus,
     &.has-attention  {
         border-color: @navy-80;
+        background: rgba(0,45,114,0.5);
     }
     &:focus {
         outline: 1px dotted @navy;
@@ -133,17 +134,18 @@
 .expandable-group .expandable__form-explainer-checklist {
     & {
         background: @gold-20;
+        border: 3px solid;
+        border-color: @gold-20;
     }
     &:hover,
     &.has-attention {
+        & {
+            border-color: rgb(255,177,73);
+        }
         .expandable_header {
             background: rgb(255,177,73);
         }
-        &.expandable__expanded {
 
-            border: 3px solid;
-            border-color: rgb(255,177,73);
-        } 
         .expandable_category:before {
             content: "\e101"; // .cf-icon-approved-round
             color: @black;
@@ -176,11 +178,27 @@
 }
 
 .expandable-group .expandable__form-explainer-definitions {
-    &,
-    &:hover,
-    &.expandable__expanded,
-    &.has-attention {
+
+    & {
         background: @navy-20;
+        border: 3px solid;
+        border-color: @navy-20;
+    }
+    &:hover,
+    &.has-attention {
+
+        & {
+            border-color: rgb(127,150,184);
+        }
+
+        .expandable_header {
+            background: rgb(127,150,184);
+        }
+
+        .expandable_category:before {
+            content: "\e105"; // .cf-icon-help-round
+            color: @black;
+        }
     }
     .expandable_category:before {
         content: "\e105"; // .cf-icon-help-round

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -68,17 +68,17 @@
 
 .image-map_overlay__definitions {
     & {
-        background: rgba(0,45,114,0.2);
+        background: rgba(0,94,93,0.2);
     }
     
     &:hover,
     &:focus,
     &.has-attention  {
-        border-color: @navy-80;
-        background: rgba(0,45,114,0.5);
+        border-color: @teal-80;
+        background: rgba(0,94,93,0.5);
     }
     &:focus {
-        outline: 1px dotted @navy;
+        outline: 1px dotted @teal;
         outline-offset: 1px;
     }
 }
@@ -96,6 +96,14 @@
     transition: transform 100ms ease-out;
     &.has-attention {
         transform: translateX(-(@grid_gutter-width / 2));
+        .expandable_link {
+            color: @black;
+        }
+    }
+    &:hover {
+        .expandable_link {
+            color: @black;
+        }
     }
     .expandable_header-left {
         max-width: 90%;
@@ -140,15 +148,18 @@
     &:hover,
     &.has-attention {
         & {
-            border-color: rgb(255,177,73);
+            border-color: @gold-80;
         }
         .expandable_header {
-            background: rgb(255,177,73);
+            background: @gold-80;
         }
 
         .expandable_category:before {
             content: "\e101"; // .cf-icon-approved-round
             color: @black;
+        }
+        .expandable_content:before {
+            background: @gold-20;
         }              
     }
 
@@ -180,32 +191,36 @@
 .expandable-group .expandable__form-explainer-definitions {
 
     & {
-        background: @navy-20;
+        background: @teal-20;
         border: 3px solid;
-        border-color: @navy-20;
+        border-color: @teal-20;
     }
     &:hover,
     &.has-attention {
 
         & {
-            border-color: rgb(127,150,184);
+            border-color: @teal-50;
         }
 
         .expandable_header {
-            background: rgb(127,150,184);
+            background: @teal-50;
         }
 
         .expandable_category:before {
             content: "\e105"; // .cf-icon-help-round
             color: @black;
         }
+
+        .expandable_content:before {
+            background: @teal-20;
+        } 
     }
     .expandable_category:before {
         content: "\e105"; // .cf-icon-help-round
-        color: @navy-80;
+        color: @teal-80;
     }
     .expandable_content:before {
-        background: @navy-50;
+        background: @teal-50;
     }
 }
 
@@ -239,9 +254,9 @@
         }
       }
       &.tab-link__definitions {
-        border-top-color: @navy-20;
+        border-top-color: @teal-20;
         .cf-icon {
-          color: @navy-50;
+          color: @teal-50;
         }
       }
       
@@ -260,9 +275,9 @@
         }
       }
       &.tab-link__definitions {
-        border-top-color: @navy-80;
+        border-top-color: @teal-80;
         .cf-icon {
-          color: @navy-80;
+          color: @teal-80;
         }
       }
     }


### PR DESCRIPTION
### Changes
* Definition color changed from navy to teal for accessibility
* When hovering over the right box, the title background and show/hide button will be darken
* When hovering over the box in the form on the left, the title background and show/hide button on the right box will be darken

### Reviews
@stephanieosan @virginiacc @cfarm 

### Screenshots
#### Check Details:
*Hover over the box in the form on the left:*
<img width="1141" alt="screen shot 2015-07-29 at 12 43 42 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963763/c823db72-35ef-11e5-9508-1b0b4c881261.png">
<img width="1137" alt="screen shot 2015-07-29 at 12 44 24 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963768/d222ae32-35ef-11e5-97e8-f7d9978dcd8b.png">

*Hover over the box on the right:*
<img width="1138" alt="screen shot 2015-07-29 at 12 43 55 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963786/e8d27450-35ef-11e5-8543-3f4aa06334b4.png">
<img width="1139" alt="screen shot 2015-07-29 at 12 44 09 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963790/eb5d5b0e-35ef-11e5-85d5-1bb7c88d09a2.png">

### Get Definitions:
*Hover over the box in the form on the left:*
<img width="1140" alt="screen shot 2015-07-29 at 12 44 40 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963803/fbe1d540-35ef-11e5-9ae4-60ad77bc36c1.png">
<img width="1140" alt="screen shot 2015-07-29 at 12 44 54 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963805/feeb33da-35ef-11e5-917e-b28212fe0372.png">

*Hover over the box on the right:*
<img width="1140" alt="screen shot 2015-07-29 at 12 44 46 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963808/08343ec8-35f0-11e5-8536-6a1ff929662a.png">
<img width="1136" alt="screen shot 2015-07-29 at 12 45 01 pm" src="https://cloud.githubusercontent.com/assets/2673022/8963811/0a7d9832-35f0-11e5-8dd0-10cfc7fb6c7c.png">

