### PR TITLE
Loan Comparison: Separate interest rate and number each steps

### DIFF
--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -1062,7 +1062,7 @@ table.unstyled {
 
 }
 
-.app-container {
+.with-link {
     & a {
     border-width: 0;
     border-style: dotted;

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -1059,4 +1059,15 @@ table.unstyled {
   float: left;
   margin-top: -3px;
   margin-right: 10px;
+
+}
+
+.app-container {
+    & a {
+    border-width: 0;
+    border-style: dotted;
+    border-color: #0072ce;
+    color: #0072ce;
+    text-decoration: none;
+  }
 }

--- a/src/static/css/module/loan-comparison.less
+++ b/src/static/css/module/loan-comparison.less
@@ -677,10 +677,6 @@
   }
 }
 
-.outputs-heading {
-  margin-left: @grid_gutter-width*2;
-}
-
   .results-section-heading {
     margin: 0;
     > .cf-icon {
@@ -1052,3 +1048,15 @@ table.unstyled {
   display: none;
 }
 
+/* Title Heading */
+.round-step {
+  width: 1.5em;
+  height: 1.5em;
+  border-radius: 1.5em;
+  line-height: 1.5;
+  text-align: center;
+  background-color: @green-tint;
+  float: left;
+  margin-top: -3px;
+  margin-right: 10px;
+}

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -111,7 +111,7 @@ var App = React.createClass({
             <div className="block">
                 <div className="content-l">
                     <div className="content-l_col content-l_col-3-4">
-                        <h3><span className="round-step">2</span>Choose interest rates to use in your scenarios</h3>
+                        <h3><span className="round-step">2</span>Choose <a href="/check-rates">interest rates</a> to use in your scenarios</h3>
                         <div className="lc-inputs" id="loan-interest-rate-container">
                             <InterestRateTable loans={this.state.loans} scenario={this.state.scenario}/>
                         </div>

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -110,8 +110,9 @@ var App = React.createClass({
             </div>
             <div className="block">
                 <div className="content-l">
-                    <div className="content-l_col content-l_col-3-4">
-                        <h3><span className="round-step">2</span>Choose <a href="/check-rates">interest rates</a> to use in your scenarios</h3>
+                    <div className="content-l_col content-l_col-3-4 with-link">
+                        <h3><span className="round-step">2</span>
+                            Choose <a class="jump-link" href="/check-rates"><span class="jump-link_text">interest rates</span></a> to use in your scenarios</h3>
                         <div className="lc-inputs" id="loan-interest-rate-container">
                             <InterestRateTable loans={this.state.loans} scenario={this.state.scenario}/>
                         </div>

--- a/src/static/js/modules/loan-comparison/components/app.js
+++ b/src/static/js/modules/loan-comparison/components/app.js
@@ -4,6 +4,7 @@ var debounce = require('debounce');
 var LoanStore = require('../stores/loan-store');
 var ScenarioStore = require('../stores/scenario-store');
 var LoanInputTable = require('./loan-input-table');
+var InterestRateTable = require('./interest-rate-table');
 var ScenarioSection = require('./scenario-section');
 var LoanOutputTableGroup = require('./loan-output-table');
 var LoanOutputTableMobileGroup = require('./loan-output-table-mobile');
@@ -87,14 +88,14 @@ var App = React.createClass({
 
     render: function() {
         return (
-          <div>
-            
+          <div>            
             <div>
                 <ScenarioSection scenario={this.state.scenario}/>
                 <div className="block block__border-top block__padded-top" id="loans-container">
                     <ScenarioHeader scenario={this.state.scenario}/>
                     <div className="content-l">
                         <div className="content-l_col content-l_col-3-4">
+                            <h3><span className="round-step">1</span>Enter details for each scenario</h3>
                             <LoanOutputTableMobileGroup loans={this.state.loans} scenario={this.state.scenario} />
                             <div className="lc-inputs" id="loan-input-container">
                                 <a href="#lc-input-0" className="lc-save-link lc-toggle first-save">
@@ -107,13 +108,32 @@ var App = React.createClass({
                     </div>
                 </div>
             </div>
-            <div>
-                <div className="content-l content-l__large-gutters">
-                    <h3 className="content-l_col content-l_col-1-2 outputs-heading">Based on the information above, here are the projected costs.</h3>
+            <div className="block">
+                <div className="content-l">
+                    <div className="content-l_col content-l_col-3-4">
+                        <h3><span className="round-step">2</span>Choose interest rates to use in your scenarios</h3>
+                        <div className="lc-inputs" id="loan-interest-rate-container">
+                            <InterestRateTable loans={this.state.loans} scenario={this.state.scenario}/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div className="block">
+                <div className="content-l">
+                    <div className="content-l_col content-l_col-3-4">
+                        <h3><span className="round-step">3</span>See how different factors affect your projected costs</h3>
+                    </div>
                 </div>
                 <LoanOutputTableGroup loans={this.state.loans} scenario={this.state.scenario} />
             </div>
-            <NextSteps scenario={this.state.scenario}/>
+            <div className="block">
+                <div className="content-l">
+                    <div className="content-l_col content-l_col-3-4">
+                        <h3><span className="round-step">4</span>Next steps</h3>
+                    </div>
+                </div>
+                <NextSteps scenario={this.state.scenario}/>
+            </div>
           </div>
         );
     },

--- a/src/static/js/modules/loan-comparison/components/interest-rate-table.js
+++ b/src/static/js/modules/loan-comparison/components/interest-rate-table.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var common = require('../common');
+var LoanInputRow = require('./loan-input-table-row');
+
+var InterestRateTable = React.createClass({
+
+    render: function() { 
+        return (
+            <table className="unstyled loan-input-table">  
+                <LoanInputRow prop="interest-rate" loans={this.props.loans} scenario={this.props.scenario}/>
+            </table>
+        );
+    }
+});
+
+module.exports = InterestRateTable;

--- a/src/static/js/modules/loan-comparison/components/loan-input-table.js
+++ b/src/static/js/modules/loan-comparison/components/loan-input-table.js
@@ -11,7 +11,7 @@ var LoanInputTable = React.createClass({
     render: function() { 
         return (
             <table className="unstyled loan-input-table">
-                <tr className="header-row"><th colSpan="4"><h3>1. About you</h3></th></tr>
+                <tr className="header-row"><th colSpan="4"><h3>About you</h3></th></tr>
                 <tr className="subhead-row">
                     <th></th>
                     <th className="input-0"><h4>Scenario A</h4></th>
@@ -20,13 +20,12 @@ var LoanInputTable = React.createClass({
                 </tr>
                 {this.inputRows(['state', 'county', 'credit-score'])}
                 
-                <tr className="header-row"><th colSpan="4"><h3>2. About the home</h3></th></tr>
+                <tr className="header-row"><th colSpan="4"><h3>About the home</h3></th></tr>
                 {this.inputRows(['price', 'downpayment', 'loan-amount'])}
 
-                <tr className="header-row"><th colSpan="4"><h3>3. About the loan</h3></th></tr>
+                <tr className="header-row"><th colSpan="4"><h3>About the loan</h3></th></tr>
                 {this.inputRows(['rate-structure', 'arm-type', 'loan-term', 'loan-type', 'loan-summary', 'points'])}     
 
-                {this.inputRows(['interest-rate'])}
                 
             </table>
         );

--- a/src/static/js/modules/loan-comparison/components/next-steps.js
+++ b/src/static/js/modules/loan-comparison/components/next-steps.js
@@ -11,7 +11,6 @@ var NextSteps = React.createClass({
             <div className="next-steps-container">
                 <div className="content-l content-l__main">
                     <div className="content-l_col content-l_col-1">
-                        <h2 className="u-mb-0">Next steps</h2>
                         <div id="next-steps">
                             <div className="step-block">
                                 <h3 className="h4">Print your information</h3>


### PR DESCRIPTION
### Changes
- Separating out the interest rate from the rest of the inputs
- Adding numbered headers to the 4 sections (inputs, interest rate, outputs, next steps)
- Removing numbers from the input categories (about you, about the home, about the loan)

### Reviews
@stephanieosan @cfarm @virginiacc 

Questions for @stephanieosan:
* Did you want "interest rates" to be linked to somewhere under "2. choose interest rates in your scenarios"?
* In output, you see how the green bleeds to the left edge, do you really want that there?  Esp if we have big screen, it looks kind of odd


### Screenshots
<img width="1440" alt="screen shot 2015-07-30 at 2 14 07 pm" src="https://cloud.githubusercontent.com/assets/2673022/8991230/5c24d54e-36c5-11e5-8aa0-c3b8db9518f9.png">

<img width="1440" alt="screen shot 2015-07-30 at 2 14 20 pm" src="https://cloud.githubusercontent.com/assets/2673022/8991234/5dd9b4d6-36c5-11e5-841c-8685feaa74b9.png">

<img width="1440" alt="screen shot 2015-07-30 at 2 14 29 pm" src="https://cloud.githubusercontent.com/assets/2673022/8991235/5f2da842-36c5-11e5-87f6-2d5c1424e1ac.png">
