### PR TITLE
Form explainer: stop using deprecated .load() method

### DIFF
--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -112,7 +112,8 @@ function stickImage($el) {
 function fitAndStickToWindow(els, pageNum) {
   // http://stackoverflow.com/questions/318630/get-real-image-width-and-height-with-javascript-in-safari-chrome
   $('<img/>')
-    .load( function() {
+    .on('load', function() {
+        console.log('load')
       // store image width for use in calculations on window resize
       if (pageNum) {
         storeImageDimensions(els.$imageMapImage);

--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -113,7 +113,6 @@ function fitAndStickToWindow(els, pageNum) {
   // http://stackoverflow.com/questions/318630/get-real-image-width-and-height-with-javascript-in-safari-chrome
   $('<img/>')
     .on('load', function() {
-        console.log('load')
       // store image width for use in calculations on window resize
       if (pageNum) {
         storeImageDimensions(els.$imageMapImage);


### PR DESCRIPTION
### Changes
- use .on() instead of .load()

### Review
- @cfarm