### PR TITLE
fix(js bug): add missing loan options js file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
     concat: {
       'cf-less': {
         src: [
-        'src/static/vendor/fj-*/*.less', 
+        'src/static/vendor/fj-*/*.less',
         'src/static/vendor/cf-*/*.less',
         '!src/static/vendor/cf-core/*.less',
         'src/static/vendor/cf-core/cf-core.less',
@@ -121,8 +121,9 @@ module.exports = function(grunt) {
           './src/static/js/modules/loan-estimate.js',
           './src/static/js/modules/closing-disclosure.js',
           './src/static/js/modules/process.js',
-          './src/static/js/modules/home.js'
-          
+          './src/static/js/modules/home.js',
+          './src/static/js/modules/loan-options-subpage.js'
+
         ],
         dest: 'dist/static/js/main.js',
         options: {
@@ -141,7 +142,7 @@ module.exports = function(grunt) {
                 './src/static/js/modules/process.js',
                 './src/static/js/modules/home.js',
                 './src/static/js/modules/loan-options-subpage.js'
-                
+
               ],
               o: [
                 'dist/static/js/loan-options.js',
@@ -155,7 +156,7 @@ module.exports = function(grunt) {
                 'dist/static/js/process.js',
                 'dist/static/js/home.js',
                 'dist/static/js/loan-options-subpage.js'
-                
+
               ]
             }]
           ]
@@ -247,7 +248,7 @@ module.exports = function(grunt) {
             'process.js',
             'home.js',
             'loan-options-subpage.js'
-            
+
           ],
           dest: './dist/static/js'
         }]


### PR DESCRIPTION
Fixes oah-notes 1050, JS bug on Loan Options subpages due to missing JS file in Gruntfile. See the live site for the error this fixes: http://www.consumerfinance.gov/owning-a-home/loan-options/conventional-loans/

## Additions

- adds missing js file to the build step in Gruntfile

## Testing

- check out locally and run grunt
- navigate to http://localhost:7000/loan-options/FHA-loans/ and check for "Failed to load resource: the server responded with a status of 404 (NOT FOUND) for http://localhost:7000/static/js/loan-options-subpage.js?v1" error. 
- the error should be gone
- there is a different JS error that is still being fixed that will occur on this page, " Cannot read property 'top' of undefined" please ignore :see_no_evil: 

## Review

- @virginiacc 