### PR TITLE
Fix form explainer js loading bug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,11 +117,12 @@ module.exports = function(grunt) {
           './src/static/js/modules/check-rates.js',
           './src/static/js/modules/loan-comparison.js',
           './src/static/js/modules/prepare-worksheets/prepare-worksheets.js',
-          './src/static/js/modules/form-explainer.js',
           './src/static/js/modules/loan-estimate.js',
           './src/static/js/modules/closing-disclosure.js',
           './src/static/js/modules/process.js',
-          './src/static/js/modules/home.js'
+          './src/static/js/modules/home.js',
+          './src/static/js/modules/loan-options-subpage.js'
+          
           
         ],
         dest: 'dist/static/js/main.js',
@@ -135,13 +136,11 @@ module.exports = function(grunt) {
                 './src/static/js/modules/check-rates.js',
                 './src/static/js/modules/loan-comparison.js',
                 './src/static/js/modules/prepare-worksheets/prepare-worksheets.js',
-                './src/static/js/modules/form-explainer.js',
                 './src/static/js/modules/loan-estimate.js',
                 './src/static/js/modules/closing-disclosure.js',
                 './src/static/js/modules/process.js',
                 './src/static/js/modules/home.js',
                 './src/static/js/modules/loan-options-subpage.js'
-                
               ],
               o: [
                 'dist/static/js/loan-options.js',
@@ -149,7 +148,6 @@ module.exports = function(grunt) {
                 'dist/static/js/check-rates.js',
                 'dist/static/js/loan-comparison.js',
                 'dist/static/js/prepare-worksheets.js',
-                'dist/static/js/form-explainer.js',
                 'dist/static/js/loan-estimate.js',
                 'dist/static/js/closing-disclosure.js',
                 'dist/static/js/process.js',


### PR DESCRIPTION
### Changes
- Remove form-explainer.js from browserify task so it is only used where required as a dependency

### Review
@cfarm 
