### PR TITLE
Form explainer toggle behaviour

### DIFF
--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -412,6 +412,7 @@ $(document).ready(function(){
       duration: 200,
       offset: -30
     });
+    $(itemID).get(0).handleClick(event);
   });
 
   $WRAPPER.on( 'focus', '.expandable__form-explainer, .expandable__form-explainer .expandable_target', function( ) {


### PR DESCRIPTION
### Additions
- when a highlighted area of the form image is clicked, the associated explanation is toggled open (or closed)

### Review
@cfarm 