### PR TITLE
Form explainer fix: IE8 highlights

### DIFF
--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -60,11 +60,22 @@
 }
 
 .lt-ie9 .image-map_overlay__checklist {
-    background:none;
+   background:none;
     -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
     filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
     zoom: 1;
 }
+
+.lt-ie9 .image-map_overlay__checklist:hover,
+.lt-ie9 .image-map_overlay__checklist:focus,
+.lt-ie9 .image-map_overlay__checklist.has-attention  {
+    background:none;
+    -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
+    filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
+    zoom: 1;
+    border-color: @gold-80;
+}
+
 
 .image-map_overlay__definitions {
     & {
@@ -84,12 +95,18 @@
 }
 
 .lt-ie9 .image-map_overlay__definitions {
-    background:none;
-    -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33002D72,endColorstr=#33002D72)";
-    filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33002D72,endColorstr=#33002D72)";
-    zoom: 1;
+  background:none;
+  -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33005E5D,endColorstr=#33005E5D)";
+  filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33005E5D,endColorstr=#33005E5D)";
+  zoom: 1;
+  
+  &:hover,
+  &:focus,
+  &.has-attention  {
+      -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7F005E5D,endColorstr=#7F005E5D)";
+      filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7F005E5D,endColorstr=#7F005E5D)";
+  }
 }
-
 .expandable-group .expandable__form-explainer {
     border-bottom: none;
     margin: 0 0 unit(3px / @base-font-size-px, em);

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -64,18 +64,14 @@
     -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
     filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#33FF931B,endColorstr=#33FF931B)";
     zoom: 1;
+    
+    &:hover,
+    &:focus,
+    &.has-attention  {
+        -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
+        filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
+    }
 }
-
-.lt-ie9 .image-map_overlay__checklist:hover,
-.lt-ie9 .image-map_overlay__checklist:focus,
-.lt-ie9 .image-map_overlay__checklist.has-attention  {
-    background:none;
-    -ms-filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
-    filter:~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#7FFF931B,endColorstr=#7FFF931B)";
-    zoom: 1;
-    border-color: @gold-80;
-}
-
 
 .image-map_overlay__definitions {
     & {


### PR DESCRIPTION
### Changes
- Update definitions highlight filters to use new teal

### Additions
- Add `.has-attention` (and hover state?) highlight filters for IE8

### Preview
<img width="1111" alt="screen shot 2015-08-05 at 7 31 32 pm" src="https://cloud.githubusercontent.com/assets/778171/9100437/ea5e614e-3ba8-11e5-929a-86c27f96c47a.png">

<img width="1090" alt="screen shot 2015-08-05 at 7 49 18 pm" src="https://cloud.githubusercontent.com/assets/778171/9100639/55485562-3bab-11e5-82cc-67863066943b.png">


### Testing
This will need to be tested in Saucelabs. Open loan estimate in IE8 & see darker highlight on image map when associated explanation is hovered over/clicked.

### Notes
I'm having trouble seeing the hover state for the image map links. Not sure if this is Saucelabs or another bug.

### Review 
@cfarm