### PR TITLE
Fix issue with link not wrapping

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -262,7 +262,7 @@
 
           <ul class="list__unstyled list__spaced">
             <li class="list_item">
-                <a class="icon-link__no-wrap jump-link jump-link__download" href="http://www.consumerfinance.gov/f/201503_cfpb_your-home-loan-toolkit-web.pdf" target=\"_blank\">
+                <a class="jump-link jump-link__download" href="http://www.consumerfinance.gov/f/201503_cfpb_your-home-loan-toolkit-web.pdf" target=\"_blank\">
                   <span class="jump-link_text">Your home loan toolkit: a step-by-step guide</span>
                 </a>
             </li>


### PR DESCRIPTION
This link was running off the edge of the screen at all widths under about 1200, so I removed the `icon-link__no-wrap` class, which seemed to be serving no purpose.