### PR TITLE
Add cobertura reporter for easier Jenkins integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -399,6 +399,7 @@ module.exports = function(grunt) {
           coverageFolder: 'test/coverage',
           coverage: true,
           excludes: ['src/static/vendor/**/*'],
+          reportFormats: ['cobertura','lcov'],
           check: {
             lines: 50,
             statements: 50


### PR DESCRIPTION
This would useful at reviewing the test failures in Jenkins and tracking tests over time.