### PR TITLE
Form explainer: update scroll-to position for expandables

### DIFF
--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -407,12 +407,29 @@ $(document).ready(function(){
   // the page until it is in view.
   $WRAPPER.on( 'click', '.image-map_overlay', function( event ) {
     event.preventDefault();
+    var offset = 0;
     var itemID = $( this ).attr('href');
-    $.scrollTo( $(itemID), {
+    var $targetExpandable = $(itemID);
+    
+    // If there's an expandable open above the targeted expandable,
+    // it will be closed when this expandable opens, so we need
+    // to subtract its height from this expandable's offset in order
+    // to get a position to use in scrolling this expandable into view
+    // ALTERNATIVE, if this is buggy: if there's an expandable open above,
+    // just delay the scroll until we estimate the expandable has closed (maybe 500?)
+    var prevExpanded = $targetExpandable.prevAll('.expandable__expanded');
+    if (prevExpanded.length) {
+      offset = $(prevExpanded[0]).find('.expandable_content').height();
+    }
+    var pos = $targetExpandable.offset().top - offset;
+    
+    $.scrollTo( pos, {
       duration: 200,
       offset: -30
     });
+    $targetExpandable.get(0).handleClick(event);
   });
+  
 
   $WRAPPER.on( 'focus', '.expandable__form-explainer, .expandable__form-explainer .expandable_target', function( ) {
     var $this = $(this),


### PR DESCRIPTION
Addresses issue raised in GHE 1059. 

When a form explainer image map link is clicked, the associated expandable is opened & scrolled into view, and any other open expandable is closed. The problem seems to be that the scroll-to position is calculated from the targeted expandable's position *before* the expandable animations take place -- so if an expandable above the targeted one is collapsed in this process, we'll wind up scrolling too far down the page & part of the targeted expandable will be offscreen.

## Changes
- When form explainer image map link is clicked, subtracts content height of any previous open expandable from targeted expandable's offset top to determine scroll-to position

## Testing
1. Open first expandable on form explainer page. 
2. Click the image map link for an expandable further down the page.
3. Make sure that the targeted expandable is not partially offscreen when scrolled into view.

## Preview
This is the problematic positioning logged in issue 1059:

![5f2b8bc4-3cfc-11e5-9983-e33b6eaaf6d5](https://cloud.githubusercontent.com/assets/778171/9143593/5d443040-3d15-11e5-8305-76f605cb2ac9.png)



This is the positioning you should see:

<img width="1062" alt="screen shot 2015-08-07 at 3 03 05 pm" src="https://cloud.githubusercontent.com/assets/778171/9143622/7b030638-3d15-11e5-9818-a19f6f760420.png">

## Notes
It's hard to test the scrolling behaviour on Saucelabs due to streaming lag. If it turns out that this is problematic, an alternative solution would be to delay scrolling to the targeted expandable if there's an open previous expandable until we estimate that the collapsing animation has completed.

## Review
@cfarm
@sonnakim 