### PR TITLE
Form Explainer - Pagination Browser Tests

### DIFF
--- a/src/_layouts/form-explainer.html
+++ b/src/_layouts/form-explainer.html
@@ -42,8 +42,8 @@
         <div class="image-map_wrapper">
             <div class="form-explainer_page-buttons">
                   <button class="prev btn btn__disabled">
-                      <span class="cf-icon cf-icon-left"></span>
                       <span class="u-visually-hidden">Prev page</span>
+                      <span class="cf-icon cf-icon-left"></span>
                   </button>
                   <button class="btn next">
                     <span class="u-visually-hidden">Next page</span>

--- a/test/browser_testing/features/closing_disclosure.feature
+++ b/test/browser_testing/features/closing_disclosure.feature
@@ -59,3 +59,45 @@ Examples:
   | tab_name    |
   | Checklist   |
   | Definitions |
+
+@closing_disclosure
+Scenario Outline: Test pagination
+  When I click on page "<page_num>"
+  Then page "<page_num>" is displayed
+
+Examples:
+  | page_num |
+  | 1        |
+  | 2        |
+  | 3        |
+  | 4        |
+  | 5        |
+  | 1        |
+
+
+@closing_disclosure
+Scenario Outline: Test Next Page
+  When I click page "<current_num>" in Form Explainer
+    And I click the next button in page "<current_num>"
+  Then page "<page_num>" is displayed
+
+  Examples:
+  | current_num | page_num |
+  | 1           | 2        |
+  | 2           | 3        |
+  | 3           | 4        |
+  | 4           | 5        |
+
+@closing_disclosure
+Scenario Outline: Test Prev Page
+  When I click page "<current_num>" in Form Explainer
+   And I click the previous button in page "<current_num>"
+  Then page "<page_num>" is displayed
+
+  Examples:
+  | current_num | page_num |
+  | 5           | 4        |
+  | 4           | 3        |
+  | 3           | 2        |
+  | 2           | 1        |
+ 

--- a/test/browser_testing/features/loan_estimate.feature
+++ b/test/browser_testing/features/loan_estimate.feature
@@ -59,3 +59,36 @@ Examples:
   | tab_name    |
   | Checklist   |
   | Definitions |
+
+@loan_estimate
+Scenario Outline: Test pagination
+  When I click on page "<page_num>"
+  Then page "<page_num>" is displayed
+
+Examples:
+  | page_num |
+  | 1        |
+  | 2        |
+  | 3        |
+  | 1        |
+
+  @loan_estimate @amy
+  Scenario Outline: Test Next Page
+    When I am currently on page "<current_num>" and I click next page
+    Then page "<page_num>" is displayed
+
+  Examples:
+  | current_num | page_num |
+  | 1           | 2        |
+  | 2           | 3        |
+
+  @loan_estimate @amy
+  Scenario Outline: Test Next Page
+    When I am currently on page "<current_num>" and I click previous page
+    Then page "<page_num>" is displayed
+
+  Examples:
+  | current_num | page_num |
+  | 3           | 2        |
+  | 2           | 1        |
+

--- a/test/browser_testing/features/loan_estimate.feature
+++ b/test/browser_testing/features/loan_estimate.feature
@@ -72,9 +72,10 @@ Examples:
   | 3        |
   | 1        |
 
-  @loan_estimate
+  @loan_estimate @amy
   Scenario Outline: Test Next Page
-    When I am currently on page "<current_num>" and I click next page
+    When I click page "<current_num>" in Loan Estimate
+      And I click the next button in page "<current_num>"
     Then page "<page_num>" is displayed
 
   Examples:
@@ -84,11 +85,11 @@ Examples:
 
   @loan_estimate @amy
   Scenario Outline: Test Prev Page
-    When I am currently on page "<current_num>" and I click previous page
+    When I click page "<current_num>" in Loan Estimate
+     And I click the previous button in page "<current_num>"
     Then page "<page_num>" is displayed
 
   Examples:
   | current_num | page_num |
   | 3           | 2        |
   | 2           | 1        |
-

--- a/test/browser_testing/features/loan_estimate.feature
+++ b/test/browser_testing/features/loan_estimate.feature
@@ -72,7 +72,7 @@ Examples:
   | 3        |
   | 1        |
 
-  @loan_estimate @amy
+  @loan_estimate
   Scenario Outline: Test Next Page
     When I am currently on page "<current_num>" and I click next page
     Then page "<page_num>" is displayed
@@ -83,7 +83,7 @@ Examples:
   | 2           | 3        |
 
   @loan_estimate @amy
-  Scenario Outline: Test Next Page
+  Scenario Outline: Test Prev Page
     When I am currently on page "<current_num>" and I click previous page
     Then page "<page_num>" is displayed
 

--- a/test/browser_testing/features/loan_estimate.feature
+++ b/test/browser_testing/features/loan_estimate.feature
@@ -72,9 +72,9 @@ Examples:
   | 3        |
   | 1        |
 
-  @loan_estimate @amy
+  @loan_estimate
   Scenario Outline: Test Next Page
-    When I click page "<current_num>" in Loan Estimate
+    When I click page "<current_num>" in Form Explainer
       And I click the next button in page "<current_num>"
     Then page "<page_num>" is displayed
 
@@ -83,9 +83,9 @@ Examples:
   | 1           | 2        |
   | 2           | 3        |
 
-  @loan_estimate @amy
+  @loan_estimate
   Scenario Outline: Test Prev Page
-    When I click page "<current_num>" in Loan Estimate
+    When I click page "<current_num>" in Form Explainer
      And I click the previous button in page "<current_num>"
     Then page "<page_num>" is displayed
 

--- a/test/browser_testing/features/pages/closing_disclosure.py
+++ b/test/browser_testing/features/pages/closing_disclosure.py
@@ -124,7 +124,6 @@ class ClosingDisclosure(Base):
         elements = self.driver.find_elements_by_class_name('form-explainer_page-link')
         for element in elements:
             if element.get_attribute('data-page') == page_num:
-                print "Clicked %s" % page_num
 
                 script = "arguments[0].scrollIntoView(true);"
                 self.driver.execute_script(script, element)

--- a/test/browser_testing/features/pages/closing_disclosure.py
+++ b/test/browser_testing/features/pages/closing_disclosure.py
@@ -138,21 +138,17 @@ class ClosingDisclosure(Base):
     def click_next_page(self, current_num):
         element_css = "#explain_page-" + current_num + " .next.btn"
         msg = "Element " + element_css + " NOT found!"
-        script = "arguments[0].scrollIntoView(true);"
 
         element = WebDriverWait(self.driver, self.driver_wait)\
             .until(EC.visibility_of_element_located((By.CSS_SELECTOR, element_css)), msg)
 
-        self.driver.execute_script(script, element)
         element.click()
 
     def click_prev_page(self, current_num):
         element_css = "#explain_page-" + current_num + " .prev.btn"
         msg = "Element " + element_css + " NOT found!"
-        script = "arguments[0].scrollIntoView(true);"
 
         element = WebDriverWait(self.driver, self.driver_wait)\
             .until(EC.visibility_of_element_located((By.CSS_SELECTOR, element_css)), msg)
 
-        self.driver.execute_script(script, element)
         element.click()

--- a/test/browser_testing/features/pages/closing_disclosure.py
+++ b/test/browser_testing/features/pages/closing_disclosure.py
@@ -132,7 +132,7 @@ class ClosingDisclosure(Base):
 
     def current_page(self):
         element = self.driver.find_element_by_class_name('current-page')
-        return element.get_attribute('data-page')
+        return element.text
 
     def click_next_page(self, current_num):
         element_css = "#explain_page-" + current_num + " .next.btn"

--- a/test/browser_testing/features/pages/closing_disclosure.py
+++ b/test/browser_testing/features/pages/closing_disclosure.py
@@ -112,3 +112,26 @@ class ClosingDisclosure(Base):
                         bad_elements += 1
 
         return bad_elements
+
+    def click_page(self, page_num):
+        elements = self.driver.find_elements_by_class_name('form-explainer_page-link')
+        for element in elements:
+            if element.get_attribute('data-page') == page_num:
+                print "Clicked %s" % page_num
+                element.click()
+                break
+
+
+    def current_page(self):
+        element = self.driver.find_element_by_class_name('current-page')
+        return element.get_attribute('data-page')
+
+    def click_next_page(self, current_num):
+        element = self.driver.find_element_by_css_selector('.btn.next')
+        print element.get_attribute('class')
+        element.click()
+
+    def click_prev_page(self, currrent_num):
+        element = self.driver.find_element_by_css_selector('.prev.btn')
+        print element.get_attribute('class')
+        element.click()

--- a/test/browser_testing/features/pages/closing_disclosure.py
+++ b/test/browser_testing/features/pages/closing_disclosure.py
@@ -118,6 +118,9 @@ class ClosingDisclosure(Base):
         for element in elements:
             if element.get_attribute('data-page') == page_num:
                 print "Clicked %s" % page_num
+
+                script = "arguments[0].scrollIntoView(true);"
+                self.driver.execute_script(script, element)
                 element.click()
                 break
 
@@ -134,4 +137,8 @@ class ClosingDisclosure(Base):
     def click_prev_page(self, currrent_num):
         element = self.driver.find_element_by_css_selector('.prev.btn')
         print element.get_attribute('class')
+
+        script = "arguments[0].scrollIntoView(true);"
+        self.driver.execute_script(script, element)
+
         element.click()

--- a/test/browser_testing/features/steps/steps_closing_disclosure.py
+++ b/test/browser_testing/features/steps/steps_closing_disclosure.py
@@ -63,10 +63,10 @@ def click_page(context, page_num):
 
 @then(u'page "{page_num}" is displayed')
 def page_is_current(context, page_num):
-    a = context.closing_disclosure.current_page()
+    current_page = context.closing_disclosure.current_page()
 
-    assert_that(a, equal_to(page_num),
-                'Page %s is current page' % a)
+    assert_that(current_page, equal_to(page_num),
+                'Page %s is current page' % current_page)
 
 
 @when(u'I click the next button in page "{current_num}"')
@@ -79,6 +79,6 @@ def click_prev_page(context, current_num):
     context.closing_disclosure.click_prev_page(current_num)
 
 
-@when(u'I click page "{current_num}" in Loan Estimate')
+@when(u'I click page "{current_num}" in Form Explainer')
 def click_page_number(context, current_num):
     context.closing_disclosure.click_page(current_num)

--- a/test/browser_testing/features/steps/steps_closing_disclosure.py
+++ b/test/browser_testing/features/steps/steps_closing_disclosure.py
@@ -54,3 +54,27 @@ def click_tab(context, tab_name):
 def hover_an_overlay(context):
     result = context.closing_disclosure.hover_an_overlay()
     assert_that(result, equal_to(0), 'All overlays to explainers connections work')
+
+@when(u'I click on page "{page_num}"')
+def click_page(context, page_num):
+    context.closing_disclosure.click_page(page_num)
+
+@then(u'page "{page_num}" is displayed')
+def page_is_current(context, page_num):
+    a = context.closing_disclosure.current_page()
+
+    assert_that(a, equal_to(page_num),
+                'Page %s is current page' % a)
+
+@when(u'I am currently on page "{current_num}" and I click next page')
+def click_next_page(context, current_num):
+    context.closing_disclosure.click_page(current_num)
+    context.closing_disclosure.click_next_page(current_num)
+
+@when(u'I am currently on page "{current_num}" and I click previous page')
+def click_prev_page(context, current_num):
+    context.closing_disclosure.click_page(current_num)
+    p = context.closing_disclosure.current_page()
+    assert_that(p, current_num,
+        'Current Page number is %s' % p)
+    context.closing_disclosure.click_prev_page(current_num)

--- a/test/browser_testing/features/steps/steps_closing_disclosure.py
+++ b/test/browser_testing/features/steps/steps_closing_disclosure.py
@@ -55,9 +55,11 @@ def hover_an_overlay(context):
     result = context.closing_disclosure.hover_an_overlay()
     assert_that(result, equal_to(0), 'All overlays to explainers connections work')
 
+
 @when(u'I click on page "{page_num}"')
 def click_page(context, page_num):
     context.closing_disclosure.click_page(page_num)
+
 
 @then(u'page "{page_num}" is displayed')
 def page_is_current(context, page_num):
@@ -66,18 +68,17 @@ def page_is_current(context, page_num):
     assert_that(a, equal_to(page_num),
                 'Page %s is current page' % a)
 
-@when(u'I am currently on page "{current_num}" and I click next page')
+
+@when(u'I click the next button in page "{current_num}"')
 def click_next_page(context, current_num):
-    context.closing_disclosure.click_page(current_num)
     context.closing_disclosure.click_next_page(current_num)
 
-@when(u'I am currently on page "{current_num}" and I click previous page')
+
+@when(u'I click the previous button in page "{current_num}"')
 def click_prev_page(context, current_num):
-    context.base.sleep(5)
-    context.closing_disclosure.click_page(current_num)
-    context.base.sleep(5)
-    # p = context.closing_disclosure.current_page()
-    # assert_that(p, current_num,
-    #     'Current Page number is %s' % p)
     context.closing_disclosure.click_prev_page(current_num)
-    context.base.sleep(5)
+
+
+@when(u'I click page "{current_num}" in Loan Estimate')
+def click_page_number(context, current_num):
+    context.closing_disclosure.click_page(current_num)

--- a/test/browser_testing/features/steps/steps_closing_disclosure.py
+++ b/test/browser_testing/features/steps/steps_closing_disclosure.py
@@ -73,8 +73,11 @@ def click_next_page(context, current_num):
 
 @when(u'I am currently on page "{current_num}" and I click previous page')
 def click_prev_page(context, current_num):
+    context.base.sleep(5)
     context.closing_disclosure.click_page(current_num)
-    p = context.closing_disclosure.current_page()
-    assert_that(p, current_num,
-        'Current Page number is %s' % p)
+    context.base.sleep(5)
+    # p = context.closing_disclosure.current_page()
+    # assert_that(p, current_num,
+    #     'Current Page number is %s' % p)
     context.closing_disclosure.click_prev_page(current_num)
+    context.base.sleep(5)


### PR DESCRIPTION
### Additions
* Browser Tests for Form Explainers (Both Closing Disclosure and Loan Estimate):
  * Check to make sure clicking on each page link will yield the correct page being displayed
  * Click Next Page Button will yield next page
  * Click Previous Page Button will yield previous page

### Reviews
@cfarm @virginiacc @fna 