### PR TITLE
Form explainer: fix image positioning after expandable animation

### DIFF
--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -459,6 +459,21 @@ $(document).ready(function(){
       }
     }
   });
+  
+  // Check image position after expandable animation to make sure it is not
+  // overlapping the footer.
+  var expandableTimeout;
+  $('.expandable_target').on( 'click', function( event ) {
+    var $expandable = $(this).closest('.expandable');
+    window.clearTimeout( expandableTimeout );
+      setTimeout(function () {
+        if ($WINDOW.width() > 600) {
+          var els =  formExplainer.getPageElements(formExplainer.currentPage);
+          formExplainer.updateStickiness(els, $WINDOW.scrollTop())
+
+        }
+      }, 700)
+  });
 
 });
 

--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -465,15 +465,13 @@ $(document).ready(function(){
   var expandableTimeout;
   var delay = isIE ? 1000 : 700;
   $('.expandable_target').on( 'click', function( event ) {
-    var $expandable = $(this).closest('.expandable');
     window.clearTimeout( expandableTimeout );
-      setTimeout(function () {
-        if ($WINDOW.width() > 600) {
-          var els =  formExplainer.getPageElements(formExplainer.currentPage);
-          formExplainer.updateStickiness(els, $WINDOW.scrollTop())
-
-        }
-      }, delay)
+    setTimeout(function () {
+      if ($WINDOW.width() > 600) {
+        var els =  formExplainer.getPageElements(formExplainer.currentPage);
+        formExplainer.updateStickiness(els, $WINDOW.scrollTop());
+      }
+    }, delay)
   });
 
 });

--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -463,6 +463,7 @@ $(document).ready(function(){
   // Check image position after expandable animation to make sure it is not
   // overlapping the footer.
   var expandableTimeout;
+  var delay = isIE ? 1000 : 700;
   $('.expandable_target').on( 'click', function( event ) {
     var $expandable = $(this).closest('.expandable');
     window.clearTimeout( expandableTimeout );
@@ -472,7 +473,7 @@ $(document).ready(function(){
           formExplainer.updateStickiness(els, $WINDOW.scrollTop())
 
         }
-      }, 700)
+      }, delay)
   });
 
 });


### PR DESCRIPTION
Fixes occasional issue where, when the form explainer image is fixed & the window is scrolled almost to the footer, expanding or collapsing an expandable will cause the image to be positioned over the footer. 

## Additions

- adds an expandable click handler that sets up a timeout to check the image position after expandable animation is estimated to be complete

## Review

- @cfarm @amymok

## Screenshots

### Before
<img width="1166" alt="screen shot 2015-08-18 at 12 11 42 am" src="https://cloud.githubusercontent.com/assets/778171/9322422/b1502ce2-4540-11e5-8ab0-1c9ee78718de.png">


### After
<img width="1155" alt="screen shot 2015-08-18 at 12 12 04 am" src="https://cloud.githubusercontent.com/assets/778171/9322424/b7277486-4540-11e5-82c0-ba13f8a844a9.png">


### Testing
  1. Open `loan-estimate`
  2. Click on the `Definitions` tab on the first page, and open the first term (`Monthly Principal & Interest`)
  3. Scroll down almost to the footer
  4. Click on second to last expandable (`Estimated Closing Costs`)
  5. Check whether the footer is partially covered by the form explainer image.

## Notes
- This is working for me locally in Safari & Chrome, but it's hard to verify in Saucelabs given the streaming lag. I think it's working on the iPad & IE9+ and Chrome on Windows, but I can't really tell with IE8.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices 

Windows 7
* [x] IE 11
* [x] IE 10
* [x] IE 9
* [x] IE 8
* [x] latest Chrome
* [x] latest Firefox

Mac
* [x] latest Chrome
* [x] latest Firefox
* [x] latest Safari

Mobile
* [ ] latest iPhone
* [x] latest iPad
* [ ] latest Android
* [ ] latest BlackBerry
