### PR TITLE
Journey edits

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -155,7 +155,7 @@
                         {% if step.pitfalls_to_avoid %}
                         <section class="content-l__main content-l step">
                           <h1 class="content-l_col-1-4 content-l_col h6 u-mb10">
-                            Pitfalls to avoid
+                            How to avoid pitfalls
                           </h1>
                           <article class="content-l_col-3-4 content-l_col ">
                           {{step.pitfalls_to_avoid|safe}}

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -110,7 +110,7 @@
                         <div class="content-l content-l__main">
 
                           {% if step.content %}
-                          <section class="{% if not active_phase.tools or step.key_tool%}content-l_col-2-3{% else %} step-content-full {% endif %} content-l_col short-desc">
+                          <section class="{% if not active_phase.tools or step.key_tool%}content-l_col-2-3{% else %} content-l_col-1 {% endif %} content-l_col short-desc">
                             <p>
                             {{step.content|safe}}
                             </p>

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -68,7 +68,7 @@
 
           {% if active_phase.tools %}
             <div class="tools-col">
-              <section class="tools block block__bg block__padded-top block__flush-bottom">
+              <section class="tools block block__bg block__padded-top">
                 <h3 class="h6 u-mb15">Tools for this Phase</h3>
                 {% for tool in active_phase.tools %}
                   <div class="tool">

--- a/src/process/_vars-process.html
+++ b/src/process/_vars-process.html
@@ -7,7 +7,7 @@
         },
         {
             "url": "explore",
-            "title": "Explore <br/>loan options",
+            "title": "Explore <br/>loan choices",
             "slug": "explore-loan-options"
         },
         {

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -369,6 +369,9 @@ a.list_link {
   }
     
   .steps-col {
+    .respond-to-range(600px, 799px, {
+      .grid_column(12);
+    });
     .respond-to-min(800px, {
       .grid_column(2,3);
       .grid_pull(4);
@@ -505,8 +508,17 @@ a.list_link {
   
   .phase_data {
     margin-bottom: @grid_gutter-width;
+    
+    .tools {
+      margin-bottom: @grid_gutter-width;
+    }
+    
     .respond-to-min(800px, {
       .block;
+      
+      .tools {
+        margin-bottom: 0;
+      }
     });
   }
 


### PR DESCRIPTION
Journey copy edits & assorted fixes.

## Changes
- Change `Explore loan options` to `Explore loan choices` in nav
- Change step section title `Pitfalls to avoid` to `How to avoid pitfalls`
- Add `.content-l_col-1` class to `.step-content` when there is no key_tool to ensure correct margins (fixes GHE 1086)
- Fix issues with `Action steps` section on smaller screens: 
  - add grid_column behaviour between 600 & 799px
  - add top margin below 800px


## Review
@cfarm @amymok @stephanieosan @mthibos

## Screenshots
__Explore phase title change in nav:__

<img width="1056" alt="screen shot 2015-08-20 at 1 58 23 pm" src="https://cloud.githubusercontent.com/assets/778171/9391231/9772dba8-4743-11e5-8c91-4e2587f03b30.png">

__Pitfalls section title change:__

<img width="776" alt="screen shot 2015-08-20 at 12 46 36 pm" src="https://cloud.githubusercontent.com/assets/778171/9390728/f2519c38-4740-11e5-821d-afdc530f5aaf.png">

__Fixed indentation on step content:__

<img width="716" alt="screen shot 2015-08-20 at 12 46 48 pm" src="https://cloud.githubusercontent.com/assets/778171/9390748/1064d1e0-4741-11e5-8095-5634d72400fc.png">


__Action steps on medium screens, before:__

<img width="631" alt="screen shot 2015-08-20 at 1 26 02 pm" src="https://cloud.githubusercontent.com/assets/778171/9390772/2ed55884-4741-11e5-8b61-ebd8d0862264.png">


__Action steps on medium screens, after:__

<img width="639" alt="screen shot 2015-08-20 at 1 25 35 pm" src="https://cloud.githubusercontent.com/assets/778171/9390781/3806af34-4741-11e5-9468-da75f08010e7.png">


__Action steps on small screens, before:__

<img width="470" alt="screen shot 2015-08-20 at 1 26 14 pm" src="https://cloud.githubusercontent.com/assets/778171/9390790/429e1a72-4741-11e5-88fd-87e44e0a7193.png">


__Action steps on small screens, after:__


<img width="472" alt="screen shot 2015-08-20 at 1 26 28 pm" src="https://cloud.githubusercontent.com/assets/778171/9390794/4c54750c-4741-11e5-870c-62498291c82d.png">


## Notes

- The phase names are hardcoded in the nav, but they're pulled from WordPress for the page titles, so I also updated the Explore phase in WP on build.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Visually tested in supported browsers and devices 

Windows 7
* [x] IE 11
* [x] IE 10
* [x] IE 9
* [x] IE 8
* [x] latest Chrome
* [x] latest Firefox

Mac
* [x] latest Chrome
* [x] latest Firefox
* [x] latest Safari

Mobile
* [x] latest iPhone
* [x] latest iPad