### PR TITLE
loan options grid fixes

### DIFF
--- a/src/static/css/module/loan-options.less
+++ b/src/static/css/module/loan-options.less
@@ -17,6 +17,7 @@ ul.unindent-ul{
   }
   .content__1-3 & {
     .respond-to-min(870px, {
+      border-right-width: 0;
       border-left-width: 30px;
     });
   }

--- a/src/static/css/module/loan-type.less
+++ b/src/static/css/module/loan-type.less
@@ -220,6 +220,9 @@
   strong {
     .webfont-demi();
   }
+  .col-7 {
+    border-right-width: 0;
+  }
 }
 
 @media (min-width: 1100px) {


### PR DESCRIPTION
fixes ghe1088, wonky loan options grid widths on the loan term calculator.

## Changes

- remove border widths on 2 elements so that the problematic text doesn't wrap weirdly

## Review

- @stephanieosan 

## Screenshots

Before
![screen shot 2015-08-20 at 4 44 07 pm](https://cloud.githubusercontent.com/assets/702526/9395146/b1fe9fcc-475a-11e5-8a98-4e0a42361a4e.png)


After
![screen shot 2015-08-20 at 4 41 09 pm](https://cloud.githubusercontent.com/assets/702526/9395142/a6a02d44-475a-11e5-9a39-82e4d43d3b16.png)

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
