### PR TITLE
Form Explainer - Browser Tests to check links (no 404)

### DIFF
--- a/test/browser_testing/features/closing_disclosure.feature
+++ b/test/browser_testing/features/closing_disclosure.feature
@@ -100,4 +100,13 @@ Scenario Outline: Test Prev Page
   | 4           | 3        |
   | 3           | 2        |
   | 2           | 1        |
+
+@check_urls @closing_disclosure
+Scenario Outline: Testing availability of pages on Closing Disclosure
+  Given I navigate to the "<page_name>" page
+  Then All links are working
+
+Examples:
+  | page_name             |
+  | Closing Disclosure    |
  

--- a/test/browser_testing/features/loan_estimate.feature
+++ b/test/browser_testing/features/loan_estimate.feature
@@ -93,3 +93,12 @@ Examples:
   | current_num | page_num |
   | 3           | 2        |
   | 2           | 1        |
+
+@check_urls @loan_estimate
+Scenario Outline: Testing availability of pages on Loan Estimate
+  Given I navigate to the "<page_name>" page
+  Then All links are working
+
+Examples:
+  | page_name             |
+  | Loan Estimate         |


### PR DESCRIPTION
Form Explainers have external several links there, to prevent accessing incorrect links, we need to put in tests to check these links 

## Additions

- Browser tests for loan estimate and closing disclosure

## Testing

- Run browser tests for loan estimate and closing disclosure.  You can run them separately in the test/brower_testing folder:  `behave -k <feature file> -t check_urls

## Review

- @cfarm @fna @virginiacc

## Checklist

* [ X ] Changes are limited to a single goal (no scope creep)
* [ X ] Code can be automatically merged (no conflicts)
* [ X ] Passes all existing automated tests
* [ X ] New functions include new tests