### PR TITLE
Form explainer new content and boxes

### DIFF
--- a/src/closing-disclosure/closing-disclosure-4.html
+++ b/src/closing-disclosure/closing-disclosure-4.html
@@ -4,6 +4,46 @@
 "terms":
 [
         {
+        "term": "How much will it cost if you make a late payment?",
+        "definition": "<p>It’s important to make your mortgage payments on time and in full, every month, to avoid fees and improve your credit record. However, it’s good to know in advance how much the fee will be if your payment is late.</p>",
+        "id": "pay-late",
+        "category": "checklist",
+        "left": "5.11%",
+        "top": "28.20%",
+        "width": "43.97%",
+        "height": "5.00%"
+        },
+        {
+        "term": "Will your lender accept partial monthly mortgage payments?",
+        "definition": "<p>If you are unable to make the full mortgage payment in a given month, your lender may not accept a partial payment. Even if the lender accepts partial payments, the lender may hold them in a separate account instead of applying them to your loan. The lender may also charge you a late fee every month until you make up the difference. The lender may also report you to the credit reporting agencies as not making your required payment. Ask questions so you understand exactly what happens if you can’t make the payment in full.</p>",
+        "id": "partial-payment",
+        "category": "checklist",
+        "left": "5.11%",
+        "top": "52.50%",
+        "width": "43.97%",
+        "height": "13.20%"
+        },
+        {
+        "term": "Will you have an escrow account?",
+        "definition": "<p>Many homeowners pay their property taxes and homeowner’s insurance as part of their monthly payment. This arrangement is called an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\">escrow account</a>. This section tells you: whether you have an escrow account, which homeownership expenses are included in the escrow account, and the estimated costs. Ask questions so you understand exactly what is included in the escrow and what isn’t. For example, homeowner’s association fees are often not included in the escrow. </p><p>If your Closing Disclosure shows that you don’t have an escrow account, but you would prefer to pay your property taxes and homeowner’s insurance monthly instead of in one large lump sum, talk to the lender</p>",
+        "id": "escrow-acc",
+        "category": "checklist",
+        "left": "50.78%",
+        "top": "11.18%",
+        "width": "43.97%",
+        "height": "8.11%"
+        },
+        {
+        "term": "If you do not have an escrow account, are you paying an escrow waiver fee to the lender?",
+        "definition": "<p>Some lenders may charge a fee if you choose not to have an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\">escrow account</a>. Did you discuss this choice with your lender? If your Closing Disclosure shows an escrow waiver fee and you would prefer to pay your property taxes and homeowner’s insurance monthly into an escrow account instead of paying this fee, talk to the lender.</p>",
+        "id": "escrow-waiver",
+        "category": "checklist",
+        "left": "51.50",
+        "top": "58.90%",
+        "width": "42.75%",
+        "height": "1.80%"
+        },
+        {
         "term": "Assumption",
         "definition": "<p>If your loan allows assumptions, that means that if you sell the home, the buyer may be allowed to take over your loan on the same terms, instead of having to get a new loan. If your loan does not allow assumptions, the buyer will not be allowed to take over your loan. Most loans do not allow assumptions.</p>",
         "id": "assumption",

--- a/src/closing-disclosure/closing-disclosure-4.html
+++ b/src/closing-disclosure/closing-disclosure-4.html
@@ -31,14 +31,14 @@
         "left": "50.78%",
         "top": "11.18%",
         "width": "43.97%",
-        "height": "8.11%"
+        "height": "41.50%"
         },
         {
         "term": "If you do not have an escrow account, are you paying an escrow waiver fee to the lender?",
         "definition": "<p>Some lenders may charge a fee if you choose not to have an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\">escrow account</a>. Did you discuss this choice with your lender? If your Closing Disclosure shows an escrow waiver fee and you would prefer to pay your property taxes and homeowner’s insurance monthly into an escrow account instead of paying this fee, talk to the lender.</p>",
         "id": "escrow-waiver",
         "category": "checklist",
-        "left": "51.50",
+        "left": "51.50%",
         "top": "58.90%",
         "width": "42.75%",
         "height": "1.80%"

--- a/src/loan-estimate/loan-estimate-2.html
+++ b/src/loan-estimate/loan-estimate-2.html
@@ -4,7 +4,7 @@
 'terms':
 [
         {
-        "term": "Compare the Originiation Charges to Loan Estimates from other lenders",
+        "term": "Compare the Origination Charges to Loan Estimates from other lenders",
         "definition": "<p>The best way to tell if you have a competitive loan offer is to compare it with Loan Estimates from other lenders. Origination charges are upfront fees charged by your lender, and are an important part of the cost of your loan. When comparing Loan Estimates, make sure to compare the origination charges.</p><p>Depending on the lender, origination charges may be more or less itemized. Common origination charges include application fees, origination fees, underwriting fees, processing fees, verification fees, and rate-lock fees. It’s the total that matters.</p>",
         "id": "compare-origination",
         "category": "checklist",

--- a/src/loan-estimate/loan-estimate-2.html
+++ b/src/loan-estimate/loan-estimate-2.html
@@ -3,6 +3,86 @@
 "img": url_for('static', filename='img/loan-estimate-H24B-2.png'),
 'terms':
 [
+        {
+        "term": "Compare the Originiation Charges to Loan Estimates from other lenders",
+        "definition": "<p>The best way to tell if you have a competitive loan offer is to compare it with Loan Estimates from other lenders. Origination charges are upfront fees charged by your lender, and are an important part of the cost of your loan. When comparing Loan Estimates, make sure to compare the origination charges.</p><p>Depending on the lender, origination charges may be more or less itemized. Common origination charges include application fees, origination fees, underwriting fees, processing fees, verification fees, and rate-lock fees. It’s the total that matters.</p>",
+        "id": "compare-origination",
+        "category": "checklist",
+        "left": "7.00%",
+        "top": "11.55%",
+        "width": "41.50%",
+        "height": "1.80%"
+    },
+    {
+        "term": "Does your loan include points?",
+        "definition": "<p>If there is an amount listed on this line, it means that you are paying points to the lender to reduce your interest rate. Did you discuss this choice with the lender? A similar loan may also be available without points, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more about what a rate lock is and how it works</a></p>",
+        "id": "include-points",
+        "category": "checklist",
+        "left": "7.00%",
+        "top": "13.36%",
+        "width": "41.50%",
+        "height": "1.60%"
+    },
+    {
+        "term": "Compare the Services You Cannot Shop For to Loan Estimates from other lenders",
+        "definition": "<p>TThe services in this section are required by the lender and the service providers are chosen by the lender. Because you can’t shop separately for lower prices from other providers, compare the overall cost of the items in this section to the Loan Estimates from other lenders.</p><p>Some fees in this section may depend on the <a href=\"../loan-options\" target=\"_blank\">kind of loan</a> you have chosen. For example, if you have an <a href=\"../loan-options/FHA-loans\" target=\"_blank\">FHA</a>, <a href=\"../loan-options/special-programs/#VA\" target=\"_blank\">VA</a>, or <a href=\"../loan-options/special-programs/#USDA\" target=\"_blank\">USDA</a> loan, the upfront mortgage insurance premium or funding fee will appear in this section. These fees are usually set by the government program and not the lender. If you have a <a href=\"../loan-options/conventional-loans\" target=\"_blank\">conventional loan</a> with <a href=\"/askcfpb/122/what-is-private-mortgage-insurance-how-does-pmi-work.html\" target=\"_blank\">private mortgage insurance (PMI)</a>, any upfront mortgage insurance premium would typically be listed in this section. PMI premiums are set by the private mortgage insurance company, which is usually chosen by your lender.</p>",
+        "id": "compare-lenders",
+        "category": "checklist",
+        "left": "7.00%",
+        "top": "32.00%",
+        "width": "41.50%",
+        "height": "10.10%"
+    },
+    {
+        "term": "Review the Services You Can Shop For and shop for these services",
+        "definition": "<p>The services in this section are required by the lender, but you can save money by shopping for these services separately.</p><p>Along with the Loan Estimate, the lender should provide you with a list of approved providers for each of these services. You can choose one of the providers on the list. You can also look for other providers, but check with your lender about any provider not on the list.</p><p><a href=\"../process/close/#services\" target=\"_blank\">Learn more about how to shop for these services</a></p>",
+        "id": "shop-services",
+        "category": "checklist",
+        "left": "7.00%",
+        "top": "53.00%",
+        "width": "41.50%",
+        "height": "10.00%"
+    },
+        {
+        "term": "Is the homeowner’s insurance premium accurate?",
+        "definition": "<p>The homeowner’s insurance premium is set by the homeowner’s insurance company, not by the lender. You get to choose your homeowner’s insurance company. Comparison shop to find the insurance policy you want and to learn if the amount the lender estimated is accurate for your specific situation. Usually you’ll pay the first 6 to 12 months of homeowner’s insurance at or before closing. Homeowner’s insurance is also sometimes referred to as “hazard insurance.”</p><p><a href=\"../process/close/#insurance\" target=\"_blank\">Learn more about how to shop for homeowner’s insurance</a></p>",
+        "id": "premium-accurate",
+        "category": "checklist",
+        "left": "51.40%",
+        "top": "18.50%",
+        "width": "41.50%",
+        "height": "1.60%"
+    },
+    {
+        "term": "Are the property taxes accurate?",
+        "definition": "<p>Property taxes are set by your local or state government, not by the lender. To avoid surprises later, check now to find out whether the lender has estimated these costs accurately. Contact your local tax authority or ask your real estate agent for more information about property taxes in your area.</p>",
+        "id": "taxes-accurate",
+        "category": "checklist",
+        "left": "51.40%",
+        "top": "32.50%",
+        "width": "41.50%",
+        "height": "1.60%"
+    },
+    {
+        "term": "Does your loan include lender credits?",
+        "definition": "<p>If there is an amount listed on this line, it means that the lender is giving you a rebate to offset your closing costs. You may be paying a higher interest rate in exchange for this rebate. Did you discuss this choice with the lender? A similar loan may be available with a lower interest rate and without lender credits, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more about lender credits and how they work</a></p>",
+        "id": "include-credits",
+        "category": "checklist",
+        "left": "51.40%",
+        "top": "57.00%",
+        "width": "41.50%",
+        "height": "1.60%"
+    },
+    {
+        "term": "Is the Estimated Cash to Close what you were expecting?",
+        "definition": "<p>Your Estimated Cash to Close is the estimated amount of money you will have to bring to closing. This section shows how the Estimated Cash to Close was calculated. Your Estimated Cash to Close includes your down payment and closing costs, minus any deposit you have already paid to the seller, any amount the seller has agreed to pay toward your closing costs (seller credits), and other adjustments.</p><p>If the Estimated Cash to Close isn’t what you were expecting, ask the lender to explain why. You will typically need a cashier's check or wire transfer for this amount at closing. The lender you choose will also need to document the source of the funds you bring to closing. Ask the lender about what documents you will need.</p>",
+        "id": "cash-expecting",
+        "category": "checklist",
+        "left": "51.40%",
+        "top": "74.00%",
+        "width": "41.50%",
+        "height": "2.50%"
+    },
     {
         "term": "Origination Charges",
         "definition": "<p>Upfront charges from your lender for making the loan.</p>",

--- a/src/loan-estimate/loan-estimate-3.html
+++ b/src/loan-estimate/loan-estimate-3.html
@@ -4,6 +4,36 @@
 'terms':
 [
     {
+        "term": "Is the information about the lender and loan officer what you were expecting?",
+        "definition": "<p>Is the loan officer that you are working with listed here? If not, ask questions.</p><p>Most loan officers are required to be licensed or registered with the Nationwide Mortgage Licensing System & Registry (NMLS). You can look up the loan officer by name or NMLS ID number in the NMLS database. In most cases, it will tell you whether the loan officer is authorized to operate in your state and whether there are any disciplinary actions on their record.</p>",
+        "id": "loan-officer",
+        "category": "checklist",
+        "left": "6.95%",
+        "top": "13.50%",
+        "width": "35.00%",
+        "height": "2.00%"
+    },
+    {
+        "term": "Use the Comparisons section to compare Loan Estimates",
+        "definition": "<p>This section offers several useful measures to compare the cost of this loan offer with other offers from different lenders. Because loan costs vary both across lenders and across different <a href=\"../loan-options\" target=\"_blank\">kinds of loans</a>, it’s important to <a href=\"../process/compare/#compare\" target=\"_blank\">request Loan Estimates</a> for the same kind of loan from different lenders.</p><p><a href=\"../process/compare/#request\" target=\"_blank\">Learn more about how to compare Loan Estimates from different lenders</a></p>",
+        "id": "comparisons-section",
+        "category": "checklist",
+        "left": "6.95%",
+        "top": "25.75%",
+        "width": "86.00%",
+        "height": "14.50%"
+    },
+        {
+        "term": "How much will it cost if you make a late payment?",
+        "definition": "<p>It’s important to make your mortgage payments on time and in full, every month, to avoid fees and improve your credit record. However, it’s good to know in advance how much the fee will be if your payment is late.</p>",
+        "id": "late-payment",
+        "category": "checklist",
+       "left": "6.95%",
+        "top": "62.00%",
+        "width": "86.00%",
+        "height": "4.00%"
+    },
+    {
         "term": "Annual Percentage Rate (APR)",
         "definition": "<p>The APR is one measure of your loan’s cost.</p><p><a href=\"/askcfpb/135/what-is-the-difference-between-a-mortgage-interest-rate-and-an-apr.html\" target=\"_blank\">Learn more about how your APR is different from your interest rate</a></p>",
         "id": "apr",


### PR DESCRIPTION
### Additions
* Added content to checklist category for pages 2 and 3 of Loan Estimate Explainer
* Added content to checklist category for page 4 of Closing Disclosure Explainer

### Screenshots
![screen shot 2015-08-25 at 11 11 09 am](https://cloud.githubusercontent.com/assets/6433178/9470453/09e5bff0-4b1a-11e5-93ee-75f49fe2275f.png)
![screen shot 2015-08-25 at 11 11 14 am](https://cloud.githubusercontent.com/assets/6433178/9470454/0d0dc1e6-4b1a-11e5-9fcc-fded9db6e346.png)
![screen shot 2015-08-25 at 11 10 54 am](https://cloud.githubusercontent.com/assets/6433178/9470456/11a61ef6-4b1a-11e5-8db2-b724eb8bb479.png)

### Review
@virginiacc or @cfarm or @amymok 
and @mthibos could you check that all the boxes are there and in the right spots in those screenshots? Then you can check the full content on build.