### PR TITLE
wp remove index

### DIFF
--- a/src/_lib/wordpress_journey_processor.py
+++ b/src/_lib/wordpress_journey_processor.py
@@ -92,7 +92,6 @@ def process_journey(item):
 
     del item['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'journey',
+    return {'_type': 'journey',
             '_id': item['slug'],
             '_source': item}


### PR DESCRIPTION
This is to remove passing in index so it doesn't override the index when doing sheer reindex.