### PR TITLE
Related links fixes

### DIFF
--- a/src/_layouts/related-links.html
+++ b/src/_layouts/related-links.html
@@ -144,13 +144,17 @@
     <h2 class="header-slug">
       <span class="header-slug_inner">{{data.title}}</span>
     </h2>
-    {% for link in data.links %}
-      <p class="short-desc">
-        {{link.desc}}
-      </p>
-      <a class="jump-link jump-link__block {{'jump-link__' + link.type if link.type}}" href="{{link.url}}">
-        <span class="jump-link_text">{{link.label}}</span>
-      </a>
-    {% endfor %}
+    <ul class="related-links_list">
+      {% for link in data.links %}
+        <li>
+          <p class="short-desc">
+            {{link.desc|safe}}
+          </p>
+          <a class="jump-link jump-link__block {{'jump-link__' + link.type if link.type}}" href="{{link.url}}">
+            <span class="jump-link_text">{{link.label|safe}}</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
   </div>
 {% endmacro %}

--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -10,9 +10,9 @@
 
     <div class="rate-checker result {% if subnav %}col-9{% endif %}" role="main">
 
-      <section class="page-intro wrapper">
+      <section class="page-intro content-l">
 
-        <div class="col-8">
+        <div class="content-l_col content-l_col-2-3">
 
           <div class="oah-title-tag">
             <a href="/owning-a-home/" class="go-back-link l-back-link">Owning a Home</a>
@@ -23,7 +23,7 @@
           <p class="lead">Our data comes from actual lenders and is updated every day. Credit score, loan type, home price, and down payment amount all affect the interest rate you can get. Interest is only one of the many costs you will pay when getting a mortgage. While shopping, ask about <a href="/askcfpb/136/what-are-discount-points-or-points.html" target="_blank">points</a>, <a href="/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html" target="_blank">mortgage insurance</a>, and <a href="/askcfpb/139/what-are-closing-costs.html" target="_blank">closing costs</a>. Make a final decision only after comparing lenders’ <a href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">Loan Estimates</a> which include all the costs.</p>
 
         </div>
-        <div class="col-4">
+        <div class="content-l_col content-l_col-1-3">
           <div class="rc-illu-inner">
             <img class ="rc-home-illu" src="../static/img/ill-chart.png" alt="Illustration of interest rate chart">
           </div>
@@ -423,10 +423,10 @@
             <p class="alert"><strong>Check your credit report.</strong> If you haven’t <a id="annualcreditreport" class="external-link" href="http://annualcreditreport.com" target="_blank">checked your credit report recently</a>, do so now. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank">get them corrected</a> <strong>before</strong> you apply for a mortgage.</p>
         </div> <!-- /.note -->
 
-        <section id="about" class="about">
-          <div class="wrapper">
+        <section id="about" class="about wrapper">
+          <div class="content-l content-l__large-gutters">
 
-            <div class="about-data col-8">
+            <div class="about-data content-l_col content-l_col-2-3">
               <h3 class="subhead">About this tool</h3>
 
               <p>The CFPB is a federal government agency. We are providing this tool for free, with no profit motive, to help you make more informed mortgage decisions.</p>
@@ -436,12 +436,8 @@
               <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="http://www.informars.com" target="_blank">www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
             </div>
 
-            <div class="feedback col-4">
-              <div class="tabbed-header">
-                <h3 class="subhead tabbed-heading">Feedback</h3>
-              </div>
-
-              <h4>How do we improve this tool?</h4>
+            <div class="content-l_col content-l_col-1-3">
+              <h3 class="subhead ">How do we improve this tool?</h3>
 
               <p>We're always looking to make our tools and resources better for you. Tell us how!</p>
 
@@ -477,7 +473,7 @@
            { 
              'desc': 'Wondering how much you can afford to spend?',
              'type': 'download',
-             'label': 'Get the monthly payment worksheet', 
+             'label': 'Get the monthly payment <br/> worksheet', 
              'url': '/owning-a-home/resources/monthly_payment_worksheet.pdf'
            },
            { 

--- a/src/static/css/cf-theme-overrides.less
+++ b/src/static/css/cf-theme-overrides.less
@@ -163,7 +163,7 @@
 // .block
 @block__border-top:             @gray-50;
 @block__border-bottom:          @gray-50;
-@block__bg:                     @gray-10;
+@block__bg:                     @gray-5;
 
 // .content_main
 @content_main-border:           @gray-50;

--- a/src/static/css/module/explore-rates.less
+++ b/src/static/css/module/explore-rates.less
@@ -561,11 +561,6 @@
       margin-top: 3.75em;
     }
 
-    .feedback {
-      background: @gray-5;
-      padding: 24px 15px 80px 15px;
-    }
-
 /*
     Alerts and warnings
     --------------------------- */

--- a/src/static/css/module/helpers.less
+++ b/src/static/css/module/helpers.less
@@ -360,3 +360,17 @@ object {
 .u-pb0 {
   padding-bottom: 0 !important;
 }
+
+.block__bg {
+    background-color: @block__bg;
+}
+
+.content-l_col {
+    .respond-to-min(@tablet-min, {
+        &.content-l_col-1-3 + &.content-l_col-2-3,
+        &.content-l_col-2-3 + &.content-l_col-1-3 {
+            margin-top: 0;
+        }
+    });
+}
+

--- a/src/static/css/module/related-links.less
+++ b/src/static/css/module/related-links.less
@@ -1,7 +1,17 @@
 .related-links {
-    
+  
    margin-right: -@grid_gutter-width / 2;
    margin-left: -@grid_gutter-width / 2;
+   
+   .respond-to-min(800px, {
+      margin-left: -30px;
+      margin-right: -30px;
+
+      & .content-l_col {
+        border-left-width: 30px;
+        border-right-width: 30px;
+      }
+    });
    
    .form-explainer &,
    .rate-checker_links & {
@@ -17,9 +27,26 @@
       margin-left: 0;
     });
     
-    .short-desc {
-      margin-bottom: @grid_gutter-width/6;
-      margin-top: @grid_gutter-width;
+    ul.related-links_list {
+      .list__unstyled;
+      
+      li {
+        margin-bottom: unit(28px / @base-font-size-px, em);
+      }
+      
+      .short-desc {
+        margin-bottom: unit(8px / @base-font-size-px, em);
+      }
+      
+      br {
+        display: none;
+      }
+      
+      .respond-to-min(800px, {
+        br {
+          display: block;
+        }
+      });
     }
     
     .content-l + .content-l {


### PR DESCRIPTION
Related-links style fixes.

## Changes
- Change `block__bg` color to `gray-5` for accessibility
- Increase gutter width on related links columns to prevent orphans
- Add break to monthly payment worksheet link so icon doesn't wrap to next line on desktop
- Update vertical spacing between related link components
- Tweak final explore-rates section to prevent adjacent blocks with backgrounds

## Review

- @amymok
-  @sonnakim 

## Screenshots

### changes on explore-rates page on desktop:
<img width="1049" alt="screen shot 2015-08-31 at 10 57 31 am" src="https://cloud.githubusercontent.com/assets/778171/9586255/851168a4-4fd0-11e5-8021-97cefa2b2c01.png">


### and on mobile:
<img width="437" alt="screen shot 2015-08-31 at 11 05 56 am" src="https://cloud.githubusercontent.com/assets/778171/9586258/89c6f49a-4fd0-11e5-9005-08f844f61ac2.png">

<img width="494" alt="screen shot 2015-08-31 at 10 25 15 am" src="https://cloud.githubusercontent.com/assets/778171/9586263/920a2dd4-4fd0-11e5-8b67-c9d0977ddb4a.png">




## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] Visually tested in supported browsers and devices 
