### PR TITLE
Journey: underline jump links on desktop

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -78,7 +78,7 @@
                     <p class="short-desc">{{tool.description}}</p>
                     {% endif %}
                     <a class="list_link jump-link jump-link__right" href="{{tool.link.url}}">
-                      {{tool.link.label}}
+                      <span class="jump-link_text">{{tool.link.label}}</span>
                     </a>
                   </div>
                 {% endfor %}


### PR DESCRIPTION
The links in the tools section should be underlined on desktop.

## Changes

- Wrap link text in `.jump-link_text` span so underline is applied on larger screens


## Preview

### Desktop
<img width="1047" alt="screen shot 2015-09-04 at 7 35 40 am" src="https://cloud.githubusercontent.com/assets/778171/9686259/e8d0b4da-52d7-11e5-8092-79d97d53fd25.png">

### Mobile
<img width="472" alt="screen shot 2015-09-04 at 7 38 55 am" src="https://cloud.githubusercontent.com/assets/778171/9686311/304c1534-52d8-11e5-9f96-fb49f37cf2c7.png">



## Review

- @amymok @stephanieosan 


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices 