### PR TITLE
Journey css fixes

### DIFF
--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -463,13 +463,20 @@ a.list_link {
     p {
       .short-desc;
     }
-    p + .h4 {
+    p + h2,
+    ul + h2 {
       .respond-to-min(@tablet-min, {
-        .u-mt20;
+        margin-top: unit(20px / @base-font-size-px, em)
       });
       .respond-to-min(800px, {
-        .u-mt45;
+        margin-top: unit(45px / @base-font-size-px, em)
       });
+    }
+    h2 a {
+      border-bottom-width: 1px;
+    }
+    .icon-link:after {
+      margin-left: 3px;
     }
   }
   


### PR DESCRIPTION
CSS tweaks to journey.

## Changes

- Add bottom border to links in journey step `h2`s.
- Increase space between external link text & icon
- Fix rule that increases space between subsections in WP content

## Preview

### Links in H2 elements
<img width="477" alt="screen shot 2015-09-08 at 11 46 45 am" src="https://cloud.githubusercontent.com/assets/778171/9744539/509e468a-5621-11e5-8286-953953d46786.png">

### External link icon spacing

<img width="519" alt="screen shot 2015-09-08 at 11 41 21 am" src="https://cloud.githubusercontent.com/assets/778171/9744549/58319028-5621-11e5-8129-0178d8dd39d9.png">

### Subhead spacing

<img width="765" alt="screen shot 2015-09-08 at 9 57 33 am" src="https://cloud.githubusercontent.com/assets/778171/9744554/651094b0-5621-11e5-8129-1ae6ce8481db.png">


## Notes
- I noticed that there was a css rule intended to increase the top margins (from 30px to 45px, desktop only) on the subheads in the step expandables, but it wasn't being applied because we'd changed the subhead tag from `h4` to `h2`. I updated the css so this is being applied again (in the image above, the increased top margin is on the header `Credit scores range from 300 to 850`). Does this spacing still work? @stephanieosan @huetingj 

## Review

@amymok @stephanieosan @mthibos 


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices 