### PR TITLE
Monthly payment worksheet link tooltips

### DIFF
--- a/src/static/js/modules/base.js
+++ b/src/static/js/modules/base.js
@@ -8,8 +8,7 @@ var monthlyPaymentMsg = 'Make sure to download this PDF and open it in Adobe Acr
 
 $(document).ready( function() {
   
-  $(document).tooltip({
-      selector: 'a[href$="monthly_payment_worksheet.pdf"]',
+  $('a[href$="monthly_payment_worksheet.pdf"]').tooltip({
       'placement': 'bottom',
       container: 'body',
       title: function getTooltipTitle(){

--- a/src/static/js/modules/base.js
+++ b/src/static/js/modules/base.js
@@ -1,2 +1,20 @@
 require('./nemo');
 require('./nemo-shim');
+
+var $ = jQuery = require('jquery');
+require('tooltips');
+
+var monthlyPaymentMsg = 'Make sure to download this PDF and open it in Adobe Acrobat.\nOtherwise, the calculations may not work correctly.';
+
+$(document).ready( function() {
+  
+  $(document).tooltip({
+      selector: 'a[href$="monthly_payment_worksheet.pdf"]',
+      'placement': 'bottom',
+      container: 'body',
+      title: function getTooltipTitle(){
+          return monthlyPaymentMsg;
+      }
+  });
+  
+});


### PR DESCRIPTION
Add tooltip to monthly payment worksheet links.

## Changes
- Adds tooltip via `base.js` to any link that ends in `monthly_payment_worksheet.pdf`, informing users that they need to open the file in Adobe Acrobat.

## Preview

<img width="1051" alt="screen shot 2015-09-09 at 11 15 15 am" src="https://cloud.githubusercontent.com/assets/778171/9770647/1c3ba462-56e6-11e5-987e-08c42862e45a.png">

<img width="1114" alt="screen shot 2015-09-09 at 11 13 38 am" src="https://cloud.githubusercontent.com/assets/778171/9770655/2d4d35ae-56e6-11e5-963e-fc90cd742a26.png">

<img width="378" alt="screen shot 2015-09-09 at 11 30 46 am" src="https://cloud.githubusercontent.com/assets/778171/9770663/3eedcb34-56e6-11e5-91aa-808f666b2b65.png">

<img width="383" alt="screen shot 2015-09-09 at 11 31 29 am" src="https://cloud.githubusercontent.com/assets/778171/9770675/605f1bec-56e6-11e5-8585-d821089e5a87.png">


## Review

- @amymok or @fna 
- @sonnakim or @stephanieosan


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices 