### PR TITLE
Explore rates tooltips

### DIFF
--- a/src/static/css/module/explore-rates.less
+++ b/src/static/css/module/explore-rates.less
@@ -332,11 +332,13 @@
     .webfont-demi();
     display: inline-block;
     font-size: 3em;
-    width: 20%;
+    max-width: 30%;
+    text-align: right;
+    
   }
   .text {
     display: inline-block;
-    width: 80%;
+    min-width: 70%;
   }
 }
 

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -1014,9 +1014,17 @@ function renderChart( data, cb ) {
           }
         },
         positioner: function(boxWidth, boxHeight, point) {
+          var x, y;
+          if (point.plotY < 0) {
+            x = point.plotX - 74
+            y = this.chart.plotTop - 74;
+          } else {
+            x = point.plotX - 54;
+            y = point.plotY - 66;
+          }
           return {
-            x: point.plotX - 54,
-            y: point.plotY - 66
+            x: x,
+            y: y
           };
         }
       },


### PR DESCRIPTION
Fix tooltips for bars that represent more than 10 lenders in explore rates chart.

## Changes
- Change tooltip positioner calculation to keep tooltips for 10+ bars within chart bounds.
- Use min- and max-width in css for tooltips so double-digit lender values don't overlap the rest of the text.

## Preview
### Current tooltips
<img width="715" alt="screen shot 2015-09-14 at 6 55 56 pm" src="https://cloud.githubusercontent.com/assets/778171/9866159/f82c7182-5b13-11e5-82bb-b6d17f17fc07.png">

### Updated tooltips

<img width="674" alt="screen shot 2015-09-14 at 6 56 40 pm" src="https://cloud.githubusercontent.com/assets/778171/9866167/0e19599c-5b14-11e5-8bb1-bf76b3403f16.png">

## Review

- @cfarm or @amymok 


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices
