### PR TITLE
Loan options IE expandable width bug fix

### DIFF
--- a/src/static/css/module/loan-options.less
+++ b/src/static/css/module/loan-options.less
@@ -27,6 +27,7 @@ ul.unindent-ul{
 // Expandables
 
 .type-details {
+  width: 100%;
   .expandable_header {
     background: @gray-5;
   }


### PR DESCRIPTION
Fixes IE bug where image in the loan options `interest rate type` expandable increases width of the whole expandable section.

## Changes
- Sets width of 100% on parent of the expandables section so that images in the expandables which have max-width of 100% are constrained by the width of their parent.

## Preview

#### Current Loan Options page, on IE
The expandables section becomes too wide when the `Interest Rate Type` expandable is opened because the width of the image it contains is not constrained:
<img width="1067" alt="screen shot 2015-09-15 at 10 53 49 am" src="https://cloud.githubusercontent.com/assets/778171/9885079/298038b6-5b98-11e5-9d68-18c51cb35110.png">

<img width="1068" alt="screen shot 2015-09-15 at 10 20 19 am" src="https://cloud.githubusercontent.com/assets/778171/9885194/c1fd0b82-5b98-11e5-9563-dffcb7188a5a.png">



#### Updated Loan Options page, IE

<img width="1078" alt="screen shot 2015-09-15 at 10 18 36 am" src="https://cloud.githubusercontent.com/assets/778171/9884930/56a7562c-5b97-11e5-9217-d47e30d47340.png">

<img width="1077" alt="screen shot 2015-09-15 at 10 21 26 am" src="https://cloud.githubusercontent.com/assets/778171/9885198/c9e06e52-5b98-11e5-8dd1-99b8b4c0d75a.png">



## Testing

- check out branch locally
- run `sh frontendbuild.sh`
- open saucelabs and navigate to `http:localhost:7000/loan-options` in IE10 (any IE, actually -- this is an IE-only bug)
- click to open the `Interest Rate Type` expandable
- make sure that the width of the expandable section hasn't increased

## Review

- @cfarm or @amymok 


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Visually tested in supported browsers and devices