### PR TITLE
Explore rates data labels

### DIFF
--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -1038,11 +1038,7 @@ function renderChart( data, cb ) {
           };
         }
       },
-    },    function(chartObj) {
-          $.each(chartObj.series[0].data, function(i, point) {
-              console.log(point)
-          });
-      });
+    });
 
   chart.isInitialized = true;
 

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -929,6 +929,8 @@ function renderChart( data, cb ) {
     chart.$wrapper.removeClass('geolocating');
     hc.xAxis[0].setCategories( data.labels );
     hc.series[0].setData( data.vals );
+    
+    
 
   } else {
 
@@ -996,7 +998,15 @@ function renderChart( data, cb ) {
           overflow: 'none',
           defer: true,
           color: '#919395',
+          x: 2,
+          y: 2,
           formatter: function(){
+            var point = this.point;
+            window.setTimeout(function () {
+                if(point.y > 9) {
+                    point.dataLabel.attr({y:-32, x: point.plotX - 24 });
+                }
+            });
             return '<div class="data-label">'+ this.x + '<br>|</div>';
           }
         }
@@ -1028,7 +1038,11 @@ function renderChart( data, cb ) {
           };
         }
       },
-    });
+    },    function(chartObj) {
+          $.each(chartObj.series[0].data, function(i, point) {
+              console.log(point)
+          });
+      });
 
   chart.isInitialized = true;
 


### PR DESCRIPTION
Add data labels for columns that represent more than 10 lenders in explore rates chart.

## Changes
- Add check in data label formatter for columns that represent more than 10 lenders & position label within chart area..

## Preview
### Current labelling
<img width="648" alt="screen shot 2015-09-16 at 12 19 28 am" src="https://cloud.githubusercontent.com/assets/778171/9898640/c668727c-5c08-11e5-9bf5-cdad1f93da42.png">

### Updated labels for 10+ columns

<img width="682" alt="screen shot 2015-09-16 at 12 10 17 am" src="https://cloud.githubusercontent.com/assets/778171/9898646/cdea3fbc-5c08-11e5-9e00-969dd58cc28a.png">

## Review

- @cfarm or @amymok 


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices