### PR TITLE
Process sources page: Underline H2 links

### DIFF
--- a/src/process/sources/index.html
+++ b/src/process/sources/index.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="content_wrapper content_wrapper__medium">
-    <div class="content_main">
+    <div class="content_main process-sources">
         <div class="u-mt30 u-mb30">
             <a class="list_link jump-link jump-link__left jump-link__before" href="/owning-a-home/">
                 Owning a Home

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -555,3 +555,9 @@ a.list_link {
     }
   }
 }
+
+.process-sources {
+  h2 a {
+    border-bottom-width: 1px;
+  }
+}


### PR DESCRIPTION
Underline H2 links on process sources page.

## Changes
- Add bottom border on h2 links.

## Preview

<img width="1116" alt="screen shot 2015-09-16 at 12 14 49 am" src="https://cloud.githubusercontent.com/assets/778171/9898680/2f70a8e8-5c09-11e5-9c8f-47378a9d17ba.png">


## Review

- @cfarm or @amymok 
- @stephanieosan or @huetingj 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Visually tested in supported browsers and devices