### PR TITLE
Remove tooltips from monthly payment worksheet links

### DIFF
--- a/src/static/js/modules/base.js
+++ b/src/static/js/modules/base.js
@@ -1,19 +1,3 @@
 require('./nemo');
 require('./nemo-shim');
 
-var $ = jQuery = require('jquery');
-require('tooltips');
-
-var monthlyPaymentMsg = 'Make sure to download this PDF and open it in Adobe Acrobat.\nOtherwise, the calculations may not work correctly.';
-
-$(document).ready( function() {
-  
-  $('a[href$="monthly_payment_worksheet.pdf"]').tooltip({
-      'placement': 'bottom',
-      container: 'body',
-      title: function getTooltipTitle(){
-          return monthlyPaymentMsg;
-      }
-  });
-  
-});


### PR DESCRIPTION
Remove global tooltips for monthly payment worksheet links.

## Removals
- Remove code from `base.js` that adds a tooltip to any link to monthly payment worksheet 

## Testing
-  Hover over link to monthly payment worksheet on landing page and verify that no tooltip appears

## Review

- @cfarm or @amymok 

## Screenshots

<img width="793" alt="screen shot 2015-09-16 at 8 15 29 am" src="https://cloud.githubusercontent.com/assets/778171/9909337/9f310c70-5c4c-11e5-885f-4b457a121261.png">


## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

