### PR TITLE
Remove right icon from journey tool links

### DIFF
--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -77,7 +77,7 @@
                     {% if tool.link.label %}
                     <p class="short-desc">{{tool.description}}</p>
                     {% endif %}
-                    <a class="list_link jump-link jump-link__right" href="{{tool.link.url}}">
+                    <a class="list_link jump-link" href="{{tool.link.url}}">
                       <span class="jump-link_text">{{tool.link.label}}</span>
                     </a>
                   </div>
@@ -124,7 +124,7 @@
                             <h4 class="h6 u-mb10">
                               <span class="cf-icon cf-icon-attach"></span>&nbsp;Key tool
                             </h4>
-                            <a class="jump-link jump-link__right" href="{{step.key_tool.url}}">
+                            <a class="jump-link" href="{{step.key_tool.url}}">
                               <span class="jump-link_text">{{step.key_tool.label}}</span>
                             </a>
                           </section>


### PR DESCRIPTION
Remove right arrow/caret on journey tool links so it doesn't wrap to its own line.

## Removals
- Remove `jump-link__right` class from journey tool links

## Review

- @amymok or @cfarm 
- @stephanieosan 

## Screenshots
#### Large screen
<img width="1071" alt="screen shot 2015-09-16 at 1 35 21 pm" src="https://cloud.githubusercontent.com/assets/778171/9918569/72106eae-5c7c-11e5-834f-33e281374e90.png">


#### Mobile
<img width="473" alt="screen shot 2015-09-16 at 2 04 48 pm" src="https://cloud.githubusercontent.com/assets/778171/9918580/7e51a8b8-5c7c-11e5-8ded-ab0e86f4a3dc.png">

## Notes
- We could add the icon back on mobile, like we do for the journey nav:

<img width="471" alt="screen shot 2015-09-16 at 2 04 35 pm" src="https://cloud.githubusercontent.com/assets/778171/9918595/982dd78e-5c7c-11e5-9e5a-ac47a46b0b85.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)