### PR TITLE
Form explainer dependency version fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "Placeholders.js": "jamesallardice/Placeholders.js#~3.0.2",
     "es5-shim": "~4.0.3",
     "aight": "~1.2.5",
-    "sticky": "~1.0.1",
+    "sticky": "1.0.1",
     "bootstrap": "~3.0.0",
     "console-polyfill": "latest"
   },


### PR DESCRIPTION
Specify previous release of jquery sticky plugin -- new release breaks form explainer pages.
(To see error, navigate to [loan estimate on build](http://build.consumerfinance.gov/owning-a-home/loan-estimate))

## Changes

- Set sticky plugin version in `bower.json` to 1.0.1

## Testing

- Run `sh frontendbuild.sh`
- Navigate to [loan estimate form explainer](http://localhost:7000/loan-estimate/) and make sure the page loads without errors

## Review

- @cfarm 

## Notes
- Seems like this is caused by the plugin adding support for AMD, so we can look at adapting to it when there's more time

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)