### PR TITLE
Monthly payment worksheet: link fixes

### DIFF
--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -489,7 +489,7 @@
              'urls': [
               {
                 'label': 'Get the monthly payment <br/> worksheet', 
-                 'url': '/owning-a-home/resources/monthly_payment_worksheet.pdf'
+                 'url': '/owning-a-home/monthly-payment-worksheet'
               }
              ]
            },

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
                 <h6 class="block__sub block__flush-top">Key tools</h6>
                 <ul class="list__links list__unstyled list__spaced">
                   <li class="list_item"><a class="list_link jump-link" href="{{ base_url }}explore-rates"><span class="jump-link_text">Explore interest rates</span></a></li>
-                  <li class="list_item"><a class="list_link jump-link jump-link__download" href="{{ base_url }}resources/monthly_payment_worksheet.pdf"><span class="jump-link_text">Monthly payment worksheet</span>&nbsp;</a></li>
+                  <li class="list_item"><a class="list_link jump-link" href="{{ base_url }}monthly-payment-worksheet"><span class="jump-link_text">Monthly payment worksheet</span>&nbsp;</a></li>
                 </ul>
               </div>
 

--- a/src/process/sources/index.html
+++ b/src/process/sources/index.html
@@ -97,7 +97,7 @@
             <div class="block block__border-top block__padded-top block__flush-top block__flush-bottom">
                 <div class="content-l">
                     <h2 class="content-l_col-1-4 content-l_col">
-                        <a href="/owning-a-home/resources/monthly_payment_worksheet.pdf">Monthly payment worksheet</a>
+                        <a href="/owning-a-home/monthly-payment-worksheet">Monthly payment worksheet</a>
                     </h2>
                     <article class="content-l_col-3-4 content-l_col">
                         <div class="sources-step">

--- a/src/static/js/modules/monthly-payment-worksheet.js
+++ b/src/static/js/modules/monthly-payment-worksheet.js
@@ -386,7 +386,7 @@ var MonthlyPaymentWorksheet = React.createClass({
                           <InputUSD id="homeownersInsurance" value={worksheet.homeownersInsurance} onChange={this.update.bind(null, 'homeownersInsurance')}/>
                         </div>
                         <div className="content-l_col content-l_col-1 note-row">
-                          <em>The national media is $750, but rates vary by location, the value and features of your home, and the coverage that you select.</em>
+                          <em>The national median is $750, but rates vary by location, the value and features of your home, and the coverage that you select.</em>
                         </div>
                       </div>
                       <div className="content-l input-row sources-note">


### PR DESCRIPTION
Change links to the worksheet so they go to the new page instead of the pdf


## Changes

- change MPW links (on `owning-a-home`, `owning-a-home`, and `owning-a-home/process/sources`) to go to the worksheet page instead of pdf
- fix typo on MPW 

## Review

- @cfarm or @amymok 

## Screenshots
### Typo:
<img width="488" alt="screen shot 2015-11-16 at 7 48 53 am" src="https://cloud.githubusercontent.com/assets/778171/11186427/7f1f1b2e-8c36-11e5-82c9-82c1696622fd.png">

### Fixed: 

<img width="485" alt="screen shot 2015-11-16 at 7 47 48 am" src="https://cloud.githubusercontent.com/assets/778171/11186401/5e65993a-8c36-11e5-8339-52b1890c1c9f.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)