### PR TITLE
Update cfgov-sheer-templates to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-## [1.4.1] - 2016-04-20
+## [1.4.1] - 2016-04-21
 ### Changed
-- Update cfgov-sheer-templates to get skip link styles and mega menu fix
+- Update cfgov-sheer-templates to get skip link styles and mega menu fix,
+  among other things
 
 ## [1.4.0] - 2016-04-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [1.4.1] - 2016-04-20
+### Changed
+- Update cfgov-sheer-templates to get skip link styles and mega menu fix
+
 ## [1.4.0] - 2016-04-08
 ### Changed
 - Change to cfgov-refresh header and footer
@@ -174,7 +178,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial release of the home page and loan options portion of the tool.
 
 
-[unreleased]: https://github.com/cfpb/owning-a-home/compare/v1.3.1...HEAD
+[unreleased]: https://github.com/cfpb/owning-a-home/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/cfpb/owning-a-home/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/cfpb/owning-a-home/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/cfpb/owning-a-home/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/cfpb/owning-a-home/compare/v1.2.5...v1.3.0

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "keywords": [],
   "dependencies": {
     "amortize": "0.2.2",
-    "cfgov-sheer-templates": "^2.0.1",
+    "cfgov-sheer-templates": "^2.0.2",
     "date-format": "0.0.2",
     "debounce": "0.0.3",
     "foreach": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "keywords": [],
   "dependencies": {
     "amortize": "0.2.2",
-    "cfgov-sheer-templates": "^2.0.2",
+    "cfgov-sheer-templates": "^2.0.3",
     "date-format": "0.0.2",
     "debounce": "0.0.3",
     "foreach": "2.0.4",


### PR DESCRIPTION
This adds the skip link styling and fixes the mega menu background issue.

**Testing:**
1. Check out branch to project that is sibling of cfgov-refresh
2. `npm install`
3. `grunt`
4. Load http://localhost:8000/owning-a-home/
5. Press `Tab`
6. Observe pretty skip link

**Review:**
- @kimberlymunoz
- @anselmbradford
- @jimmynotjim
- @sebworks