### PR TITLE
Updated the email signup to use the same Gov Delivery processor as cfgov-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Changed
+- Updated the email signup to use the same Gov Delivery processor as cfgov-refresh
 
 ## [1.4.1] - 2016-04-21
 ### Changed

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 {% block title %}Owning a Home{% endblock title %}
 
-{% block content %}    
+{% block content %}
 <main class="index content content__2-1 content__bleedbar" id="main" role="main">
 
     <section class="content_hero">
@@ -164,18 +164,40 @@
         <aside class="content_sidebar">
             <!-- STAY TUNED -->
           <section class="block u-mt0">
-          <header class="tabbed-header tabbed-pad-top">
-            <h3 class="subhead tabbed-heading">Stay tuned</h3>
-          </header>
-          <p>Sign up for our email list, and we’ll let you know when we add more tools and resources.</p>
+            <div class="o-email-signup">
+              <h2 class="header-slug">
+                <span class="header-slug_inner">
+                  Stay tuned
+                </span>
+              </h2>
 
-          <form class="signup2 inline-signup" id="signup" action="https://public.govdelivery.com/service/process_ss.xml" method="GET" data-thanks="Thanks, we’ll be in touch!">
-            <input type="hidden" name="code" value="USCFPB_46">
-            <label for="email" class="u-visually-hidden">Email address</label>
-            <input type="email" id="email" name="email" placeholder="Enter your email address">
-            <fieldset class="submit_btn"><p><button id="beta-btn" class="btn">Sign up</button></p></fieldset>
-          </form>
-        </section>
+              <form id="{{ ('o-email-signup_' ~ range(1, 100) | random) }}"
+                    action="/subscriptions/new/"
+                    method="POST"
+                    enctype="application/x-www-form-urlencoded">
+                <p>
+                  Sign up for our email list, and we’ll let you know when we add more tools and resources.
+                </p>
+
+                <div class="m-form-field-with-button">
+
+                  <div class="form-group">
+                    <label for="o-email-signup_address">
+                        <b>Email address</b>
+                        (required)
+                    </label>
+
+                    <input id="o-email-signup_address" type="email" placeholder="example@mail.com" name="email" class="m-form-field-with-button_field" required>
+                  </div>
+                  <input class="u-mt10 btn btn__full" type="submit" value="Sign up">
+                </div>
+
+                <div class="form-group">
+                    <input type="hidden" name="code" value="USCFPB_46">
+                </div>
+              </form>
+            </div>
+          </section>
 
           <!-- RELATED LINKS -->
           <section class="block">


### PR DESCRIPTION
The OaH email signup was using a dead GovDelivery xml schema. Replaced it with the cfgov-refresh signup. This doesn't include the scripting for an ajax request, that can come later.

## Changes

- Replaced the email signup 

## Testing

- You'll need to have cfgov-refresh installed as a sibling to test this. First, run `grunt` in OaH and then navigate to http://localhost:8000/owning-a-home/. Enter `test@test.com` and you should see a success page.

## Review

- @Scotchester 
- @rosskarchner 
- @anselmbradford 

## Screenshots

<img width="917" alt="screen shot 2016-04-20 at 8 30 09 pm" src="https://cloud.githubusercontent.com/assets/1280430/14695326/b3b6758c-0736-11e6-8164-c2e249792196.png">

## Todos

- Add ajax after launch.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
