### PR TITLE
Credit score bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "es6-promise": "^2.1.1",
     "factor-bundle": "~2.2.1",
     "flux": "^2.0.1",
-    "grunt": "latest",
+    "grunt": "~0.4.2",
     "grunt-autoprefixer": "~0.6.5",
     "grunt-banner": "latest",
     "grunt-bower-task": "~0.4.0",

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -247,7 +247,6 @@ function renderLoanAmount() {
  * @return {null}
  */
 function updateView() {
-
   chart.startLoading();
 
   // reset view
@@ -255,6 +254,7 @@ function updateView() {
 
   // Check ARM
   checkARM();
+  
 
   var data = {
     labels: [],
@@ -276,6 +276,8 @@ function updateView() {
   // And start a new one.
   if ( +params['loan-amount'] !== 0 ) {
     options['request'] = getData();
+    
+    
 
     // If it succeeds, update the DOM.
     options['request'].done(function( results ) {
@@ -312,6 +314,10 @@ function updateView() {
           data.totalVals.push(+key);
         }
       });
+      
+      
+      
+      
 
       // fade out chart and highlight county if no county is selected
       if ( $('#county').is(':visible') && $('#county').val() === null ) {
@@ -341,6 +347,7 @@ function updateView() {
       updateLanguage( data );
       renderAccessibleData( data );
       renderChart( data );
+      
 
       // Update timestamp
       var _timestamp = results.timestamp;
@@ -358,7 +365,7 @@ function updateView() {
       
       updateComparisons( data );
       renderInterestAmounts();
-
+      
     });
   }
 
@@ -814,7 +821,9 @@ function checkARM() {
  */
 function scoreWarning() {
   $('.rangeslider__handle').addClass('warning');
-  $('#slider-range').after( template.creditAlert );
+  if (!$('.credit-alert').length  > 0) {
+    $('#slider-range').after( template.creditAlert );
+  }
   resultWarning();
   // analytics code for when this event fires
   if (window._gaq) {
@@ -850,9 +859,17 @@ function downPaymentWarning() {
  */
 function removeAlerts() {
   if ($('.result-alert')) {
-    $('#chart, .rangeslider__handle').removeClass('warning');
-    $('.result-alert').remove();
+    $('#chart').removeClass('warning');
+    $('.result-alert').not('.credit-alert').remove();
     $('#dp-alert').remove();
+  }
+}
+
+
+function removeCreditScoreAlert() {
+  if ($('.credit-alert') || $('.rangeslider__handle').hasClass('warning')) {
+    $('.rangeslider__handle').removeClass('warning');
+    $('.credit-alert').remove();
   }
 }
 
@@ -881,6 +898,7 @@ function renderSlider( cb ) {
         scoreWarning();
       } else {
         updateView();
+        removeCreditScoreAlert();
       }
     }
   });
@@ -1085,6 +1103,7 @@ $('.defaults-link').click(function(ev){
   ev.preventDefault();
   setSelections({ usePlaceholder: true });
   updateView();
+  removeCreditScoreAlert();
 });
 
 // ARM highlighting handler


### PR DESCRIPTION
Fixes bug where credit score warning goes away when any input is changed (more info [here](https://github.cfpb.gov/OAH/OAH-notes/issues/443))

## Changes

- Only remove credit score warning if credit score is changed

## Testing

- Check out branch
- Run `./frontendbuild.sh`
- Navigate to [explore rates page](http://localhost:7000/explore-rates/) and move credit score slider to its lowest setting (600-619). Check that warning appears.
- Change another input's value (state, house price, etc). Check that warning still appears.
- Change credit score to higher value. Check that warning disappears.

## Review

- @cfarm or @fna 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
