### PR TITLE
Fix explore rates error messaging

### DIFF
--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -422,7 +422,7 @@ function getCounties() {
 function loadCounties() {
 
   // And request 'em.
-  request = getCounties();
+  var request = getCounties();
   request.done(function( resp ) {
 
     // If they haven't yet selected a state highlight the field.
@@ -488,7 +488,13 @@ function checkForJumbo() {
   dropdown('loan-type').enable( norms );
   dropdown('loan-type').hideHighlight();
   $('#county-warning').addClass('hidden');
-
+  
+  // if loan is not a jumbo, hide the loan type warning
+  if (jQuery.inArray(params['loan-type'], jumbos) < 0) {
+    $('#hb-warning').addClass('hidden');
+    dropdown('loan-type').hideHighlight();
+  }
+  
   // If county is not needed and loan-type is a HB loan, bounce it to a regular loan
   if ( !loan.needCounty && jQuery.inArray(params['loan-type'], jumbos) >= 0 ) {
     // Change loan-type according to the bounces object
@@ -504,14 +510,15 @@ function checkForJumbo() {
     dropdown('loan-type').enable( norms );
     dropdown('loan-type').showHighlight();
   }
-
-  // If we don't need to request a county, hide the county dropdown and jumbo options.
-  if ( !loan.needCounty && jQuery.inArray(params['loan-type'], jumbos) < 0 ) {
+  
+  
+  if (!loan.needCounty && jQuery.inArray(params['loan-type'], jumbos) < 0) {
     dropdown('county').hide();
     $('#county').val('');
     dropdown('loan-type').removeOption( jumbos );
     return;
   }
+  
   // Otherwise, make sure the county dropdown is shown.
   dropdown('county').show();
 
@@ -595,11 +602,11 @@ function processCounty() {
 
     $('#hb-warning').addClass('hidden');
     // Select appropriate loan type if loan was kicked out of jumbo
-    if ( prevLoanType === 'fha-hb' ) {
+    if ( params.prevLoanType === 'fha-hb' ) {
       $('#loan-type').val( 'fha' );
 
     }
-    else if ( prevLoanType === 'va-hb' ) {
+    else if ( params.prevLoanType === 'va-hb' ) {
       $('#loan-type').val( 'va' );
     }
     if ( $('#loan-type').val === null ) {

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -511,8 +511,8 @@ function checkForJumbo() {
     dropdown('loan-type').showHighlight();
   }
   
-  
-  if (!loan.needCounty && jQuery.inArray(params['loan-type'], jumbos) < 0) {
+  // If we don't need to request a county, hide the county dropdown and jumbo options.
+  if ( !loan.needCounty && jQuery.inArray(params['loan-type'], jumbos) < 0 ) {
     dropdown('county').hide();
     $('#county').val('');
     dropdown('loan-type').removeOption( jumbos );


### PR DESCRIPTION
Fixes bug on explore-rates where error messaging is not removed (see oah notes 1125 for more details)

## Changes

- In `isJumbo` check, remove highlighting and error messaging if initial analysis of loan shows it is not jumbo

## Testing

- Check out branch & run `frontendbuild.sh`
- Navigate to [explore-rates](http://localhost:7000/explore-rates/)
- Select `FHA` from loan type dropdown
- Increase house price to 350,000
- Select `Baldwin` from county dropdown
- Note that loan type is changed to conventional and a messaging about the change appears under the loan type dropdown
- Decrease the house price to 150,000
- Check that loan type error messaging goes away

## Review

- @cfarm  or @fna 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
