### PR TITLE
Fix explore rates dropdown sort order

### DIFF
--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -434,7 +434,7 @@ function getCounties() {
 function loadCounties() {
 
   // And request 'em.
-  request = getCounties();
+  var request = getCounties();
   request.done(function( resp ) {
 
     // If they haven't yet selected a state highlight the field.

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -334,7 +334,7 @@ function updateView() {
         return;
       }
 
-      data.uniqueLabels = $.unique( data.labels.slice(0) );
+      data.uniqueLabels = unique( data.labels.slice(0) );
 
       chart.stopLoading();
       removeAlerts();
@@ -367,6 +367,18 @@ function updateView() {
     downPaymentWarning();
   }
 };
+
+function unique (arr) {
+    var m = {}, newarr = []
+    for (var i=0; i<arr.length; i++) {
+      var v = arr[i];
+      if (!m[v]) {
+        newarr.push(v);
+        m[v]=true;
+      }
+    }
+    return newarr;
+}
 
 /**
  * Updates the sentence above the chart
@@ -698,9 +710,7 @@ function renderDownPayment() {
  */
 function updateComparisons( data ) {
   // Update the options in the dropdowns.
-  var uniqueLabels = $( data.uniqueLabels ).sort(function( a, b ) {
-    return a - b;
-  });
+  var uniqueLabels = data.uniqueLabels;
   $('.compare select').html('');
   $.each( uniqueLabels, function( i, rate ) {
     var option = '<option value="' + rate + '">' + rate + '</option>';


### PR DESCRIPTION
The sort order of the interest rates in the dropdowns is sometimes wrong because the labels are being unnecessarily re-sorted once they've had percentage signs added (See OAH notes 1114 for more info)
## Additions
- A `unique` function to replace the jQuery unique method (since it also sorts)
## Changes
- Stop sorting in the updateComparisons function (labels are already sorted at this point)
## Testing
- checkout branch and run `frontendbuild.sh`
- go to [explore rates](http://localhost:7000/explore-rates/)
- Update form: 
  - Choose `California` from state dropdown
  - Set house price to `900,000`
  - Set downpayment to `20%`
  - Choose `Alameda` from county dropdown
- Check that rates in the dropdowns are correctly sorted
## Review
- @cfarm 
## Screenshots

**Before, incorrectly sorted dropdown (on `cf.gov`):**
<img width="1106" alt="screen shot 2016-06-17 at 8 08 00 am" src="https://cloud.githubusercontent.com/assets/778171/16155542/c226e8ee-3464-11e6-9ea5-00ea3361fa13.png">

**After, correctly sorted dropdown:** (the values are slightly different because the rates api returns different values on build)

<img width="1088" alt="screen shot 2016-06-17 at 8 12 31 am" src="https://cloud.githubusercontent.com/assets/778171/16155609/fd260308-3464-11e6-8b7a-70d5c422cdf0.png">
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
