### PR TITLE
Explore rates GTM tab link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 ### Changed
 
+## [1.5.4] - 2016-06-30
+### Changed
+- Stop recording clicks on explore rates tabs as internal navigation in GTM
+
 ## [1.5.3] - 2016-06-27
 ### Changed
 - Update file version numbers
@@ -202,7 +206,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial release of the home page and loan options portion of the tool.
 
 
-[unreleased]: https://github.com/cfpb/owning-a-home/compare/v1.5.3...HEAD
+[unreleased]: https://github.com/cfpb/owning-a-home/compare/v1.5.4...HEAD
+[1.5.4]: https://github.com/cfpb/owning-a-home/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/cfpb/owning-a-home/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/cfpb/owning-a-home/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/cfpb/owning-a-home/compare/v1.5.0...v1.5.1

--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -361,10 +361,10 @@
 
           <ul class="tabs">
             <li class="tab-list active-tab">
-                <a id="plan-to-buy-tab" class="tab-link" href="#tab1">I plan to buy in the next couple of months</a>
+                <a id="plan-to-buy-tab" class="tab-link" href="#tab1" data-gtm_ignore="true">I plan to buy in the next couple of months</a>
             </li>
             <li class="tab-list">
-                <a id="wont-buy-tab" class="tab-link" href="#tab2">I won’t buy for several months</a>
+                <a id="wont-buy-tab" class="tab-link" href="#tab2" data-gtm_ignore="true">I won’t buy for several months</a>
             </li>
           </ul>
 
@@ -454,63 +454,63 @@
     <div class="u-mt30 rate-checker_links">
       {% import "related-links.html" as related_links %}
       {% set process_links = [
-          { 
+          {
             'desc': 'Just getting started?',
             'urls': [
               {
-                'label': 'Prepare to shop', 
+                'label': 'Prepare to shop',
                 'url': '/owning-a-home/process/prepare/'
               }
             ]
           },
-          { 
+          {
             'desc': 'Shopping for a home?',
             'urls': [
               {
-                'label': 'Explore loan choices', 
+                'label': 'Explore loan choices',
                 'url': '/owning-a-home/process/explore/'
               }
             ]
           },
-          { 
+          {
             'desc': 'Already have a home in mind?',
             'urls': [
               {
-                'label': 'Compare loan offers', 
+                'label': 'Compare loan offers',
                 'url': '/owning-a-home/process/compare/'
               }
             ]
           }
        ] %}
        {% set tools_links = [
-           { 
+           {
              'desc': 'Wondering how much you can afford to spend?',
              'type': 'download',
              'urls': [
               {
-                'label': 'Get the monthly payment <br/> worksheet', 
+                'label': 'Get the monthly payment <br/> worksheet',
                  'url': '/owning-a-home/monthly-payment-worksheet'
               }
              ]
            },
-           { 
+           {
               'desc': 'Wondering what kind of loan is right for you?',
               'urls': [
                 {
-                  'label': 'Understand loan options', 
+                  'label': 'Understand loan options',
                   'url': '/owning-a-home/loan-options/'
                 }
               ]
             },
-            { 
+            {
                'desc': 'Have a Loan Estimate?',
                'urls': [
                 {
-                  'label': 'Loan Estimate explainer', 
+                  'label': 'Loan Estimate explainer',
                    'url': '/owning-a-home/loan-estimate/'
                 }
                ]
-               
+
              }
         ] %}
       {{ related_links.render(process_links, tools_links) }}


### PR DESCRIPTION
Prevent GTM from recording clicks on tabs in `explore-rates` page as internal navigation

## Additions

- Add `data-gtm_ignore="true"` to tab links


## Review

- @mistergone 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

