### PR TITLE
Update rangeslider version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "cf-typography": "git://github.com/cfpb/cf-typography.git#0.7.0",
     "highcharts-release": "~3.0.10",
     "chosen": "https://github.com/harvesthq/chosen/releases/download/v1.1.0/chosen_v1.1.0.zip",
-    "rangeslider.js": "~0.2.9",
+    "rangeslider.js": "0.3.2",
     "respond": "1.4.2",
     "polyfill": "inexorabletash/polyfill",
     "Placeholders.js": "jamesallardice/Placeholders.js#~3.0.2",


### PR DESCRIPTION
JS error occurs when credit score slider is dragged on http://www.consumerfinance.gov/owning-a-home/explore-rates in iPhone Safari (#675)


## Changes

- Update `rangeslider.js` version

## Testing

- Check out branch & run frontendbuild.sh 
- Navigate to http://localhost:8000/owning-a-home/explore-rates/ in iPhone Safari and check that dragging the slider to 600, the lowest value, causes a warning message to appear in UI
- Navigate to http://localhost:8000/owning-a-home/explore-rates/ in a modern browser and check that slider still works as expected

## Review

- @contolini 
- @cfarm 

## Screenshots

Before:
<img width="757" alt="screen shot 2016-08-24 at 3 25 13 pm" src="https://cloud.githubusercontent.com/assets/778171/17950670/8b5c3368-6a11-11e6-8079-27408b98b832.png">

After:
<img width="297" alt="screen shot 2016-08-24 at 3 27 05 pm" src="https://cloud.githubusercontent.com/assets/778171/17950677/93a2ac96-6a11-11e6-9d9c-780d8717dddd.png">



## Todos

- 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

