### PR TITLE
Update README to use cfgov-refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We are working under an agile framework, and plan to use this repo to publish, r
 
 - Unix-based OS (including Macs). Windows is not supported at this time.
 - [cfgov-refresh](https://github.com/cfpb/cfgov-refresh)
-- [Virtualenv](https://virtualenv.pypa.io/en/latest/) and [Virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/#), Python modules that keep dependencies  project specific and in their own virtual environments.
+- [Virtualenv](https://virtualenv.pypa.io/en/latest/) and [Virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/#), Python modules that keep dependencies project specific and in their own virtual environments.
 - [Autoenv](https://github.com/kennethreitz/autoenv)
 - [Node](http://nodejs.org/)
 - [Grunt](http://gruntjs.com/)
@@ -26,50 +26,50 @@ We are working under an agile framework, and plan to use this repo to publish, r
 
 ### Virtualenv & Virtualenvwrapper Python modules
 
-If you already have these modules installed, [skip ahead to Sheer](#sheer-elasticsearch).
+If you already have these modules installed, [skip ahead to cfgov-refresh](#cfgov-refresh).
 
 1. Run:
-	```sh
-	pip install virtualenv virtualenvwrapper
-	```
+```sh
+pip install virtualenv virtualenvwrapper
+```
 
 ### Autoenv module
 
-If you already have [Autoenv](https://github.com/kennethreitz/autoenv) installed, [skip ahead to Sheer](#sheer-elasticsearch).
+If you already have [Autoenv](https://github.com/kennethreitz/autoenv) installed, [skip ahead to cfgov-refresh](#cfgov-refresh).
 
 1. Run:
-	```sh
-	pip install autoenv
-	```
+```sh
+pip install autoenv
+```
 
 ### Node, Grunt, Bower, Browserify
 
 1. Install [node.js](http://nodejs.org/), either v0.12 or io.js. If you're using the default version that comes with Mac OSX, you'll need to upgrade - first [install NVM](https://github.com/creationix/nvm).
 1. If you installed with NVM, then you can install and set io.js as your default node version:
-	```sh
-	nvm install iojs
-	nvm alias default iojs
-	```
+```sh
+nvm install iojs
+nvm alias default iojs
+```
 2. Install [Grunt](http://gruntjs.com/), [Bower](http://bower.io/) and [Browserify](http://browserify.org/):
-	```sh
-	npm install -g grunt-cli bower browserify
-	```
+```sh
+npm install -g grunt-cli bower browserify
+```
 
 3. Navigate to the cloned `owning-a-home` directory and install the project's node dependencies:
-	```sh
-	npm install
-	```
+```sh
+npm install
+```
 
 4. Navigate to the `config` folder. In that folder, copy the `example-config.json` file and rename it `config.json`. This can be done from the command line with the following two commands:
-	```sh
-	cd config
-	cp example-config.json config.json
-	```
+```sh
+cd config
+cp example-config.json config.json
+```
 
 5. Run grunt to build the site:
-	```sh
-	grunt
-	```
+```sh
+grunt
+```
 
 [npm-shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) is used to lock down dependencies. If you add any dependencies to package.json, re-run `npm shrinkwrap` to generate a new `npm-shrinkwrap.json` file.
 
@@ -80,7 +80,7 @@ Owning a Home can be installed and run by the cfgov-refresh app.
 1. Clone the cfgov-refresh GitHub project to wherever you keep your projects (not inside Owning a Home):
 
 ```sh
-git clone https://github.com/cfpb/sheer.git
+git clone https://github.com/cfpb/cfgov-refresh.git
 ```
 
 2. Run all the [installation steps outlined in the cfgov-refresh](https://cfpb.github.io/cfgov-refresh/installation/) repo.
@@ -98,19 +98,23 @@ python cfgov/manage.py sheer_index
 ### <a name="wordpress-indexing"></a>WordPress Indexing
 To index your content from WordPress:
 
-1. In the repo directory, copy the `.env_SAMPLE` file and name it `.env`. This can be done from the command line with the following command:
-	```sh
-	cp .evn_SAMPLE .env
-	```
+1. **In cfgov-refresh repo**, copy the `.env_SAMPLE` file and name it `.env`. This can be done from the command line with the following command:
 
-2. Add your WordPress URL in place of wordpress.domain on line 1 of `.env`.
+```sh
+cp .evn_SAMPLE .env
+```
 
-3. Run the following command inside the `/src/` or `/dist/` folder:
-	```sh
-	cd src
-	workon OAH
-	sheer index [--reindex]
-  ```
+2. Add your WordPress URL to the following line of `env` in place of `http://wordpress.url`.
+
+```
+export WORDPRESS=http://wordpress.url
+```
+
+3. Run the following command inside cfgov-refresh:
+
+```sh
+python cfgov/manage.py sheer_index
+```
 
 
 ### Rate Checker and Mortgage Insurance
@@ -140,54 +144,36 @@ The following commands need to be run as part of your daily workflow developing 
 ### Fetch changes workflow
 1. Each time you fetch from upstream, install dependencies with npm and run `grunt` to build everything:
 
-```bash
-$ npm install
-$ grunt
+```sh
+npm install
+grunt
 ```
 
 ### Elastic Search workflow
 Elastic Search needs to be running to display wordpress content:
 
-1. Use the sheer virtualenv:
+1. Use the Owning a Home virtualenv:
 
-    ```bash
-    $ workon OAH
-    ```
+```sh
+workon OAH
+```
 
 2. Stay in the base directory
 
 3. Start Elastic Search:
 
-    ```bash
-    $ elasticsearch
-    ```
-
-### Sheer workflow
-Sheer needs to be running to compile the templates in `_layouts`.
-
-1. Use the sheer virtualenv:
-	```bash
-	$ workon OAH
-	```
-
-2. Navigate to the built app directory that grunt created
-	```bash
-	$ cd dist
-	```
-
-3. Start Sheer:
-	```bash
-	$ sheer serve
-	```
-	**Note:** The first time you start sheer, you may get a firewall alert and login prompt. Hit cancel at either of these.
+```sh
+elasticsearch
+```
 
 ### Grunt workflow
 Grunt watch will recompile Less and JS everytime you save changes to those project files.
 
 1. Open a new command prompt and run:
-	```
-	$ grunt watch
-	```
+
+```sh
+grunt watch
+```
 
 To view the site browse to: <http://localhost:7000>
 
@@ -205,36 +191,36 @@ Once Chromedriver is downloaded, unzip the *chromedriver* file and copy it to a 
 
 Before running tests, you will need to set up a Python virtual environment, install dependencies, and create an enviconment.cfg file.
 
-```bash
-$ cd test/browser_testing/
-$ mkvirtualenv oah-tests
-$ pip install -r requirements.txt
+```sh
+cd test/browser_testing/
+mkvirtualenv oah-tests
+pip install -r requirements.txt
 ```
 
 Rename `test/browser_testing/features/example-environment.cfg` to `test/browser_testing/features/environment.cfg` and edit the file to point the `chromedriver_path` to your local chromedriver file.
 
 ### Running browser tests
 
-```bash
-$ workon oah-tests
-$ behave -k
+```sh
+workon oah-tests
+behave -k
 ```
 
 ## API tests
 
 Before running tests, you will need to set up a Python virtual environment, install dependencies, and create an `environment.cfg` file.
 
-```bash
-$ cd test/api_testing/
-$ mkvirtualenv oah-tests
-$ pip install requests
+```sh
+cd test/api_testing/
+mkvirtualenv oah-tests
+pip install requests
 ```
 
 Rename `test/api_testing/features/example-environment.cfg` to `test/api_testing/features/environment.cfg` and edit the file to point `ratechecker_url` and `mortgageinsurance_url` to the environment you wish to test.
 
-```bash
-$ workon oah-tests
-$ behave -k
+```sh
+workon oah-tests
+behave -k
 ```
 
 Run `behave -k -t=~prod_only` to omit production environment tests.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ We are working under an agile framework, and plan to use this repo to publish, r
 ## Dependencies
 
 - Unix-based OS (including Macs). Windows is not supported at this time.
+- [cfgov-refresh](https://github.com/cfpb/cfgov-refresh)
 - [Virtualenv](https://virtualenv.pypa.io/en/latest/) and [Virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/#), Python modules that keep dependencies  project specific and in their own virtual environments.
 - [Autoenv](https://github.com/kennethreitz/autoenv)
-- [Sheer](https://github.com/cfpb/sheer)
-- [Elasticsearch](http://www.elasticsearch.org/)
 - [Node](http://nodejs.org/)
 - [Grunt](http://gruntjs.com/)
 - [Bower](http://bower.io/)
@@ -30,8 +29,8 @@ We are working under an agile framework, and plan to use this repo to publish, r
 If you already have these modules installed, [skip ahead to Sheer](#sheer-elasticsearch).
 
 1. Run:
-	```
-	$ pip install virtualenv virtualenvwrapper
+	```sh
+	pip install virtualenv virtualenvwrapper
 	```
 
 ### Autoenv module
@@ -39,98 +38,60 @@ If you already have these modules installed, [skip ahead to Sheer](#sheer-elasti
 If you already have [Autoenv](https://github.com/kennethreitz/autoenv) installed, [skip ahead to Sheer](#sheer-elasticsearch).
 
 1. Run:
+	```sh
+	pip install autoenv
 	```
-	$ pip install autoenv
-	```
-
-
-### Sheer & Elasticsearch
-
-[Sheer](https://github.com/cfpb/sheer) is "A Jekyll-inspired, elasticsearch-powered, CMS-less publishing tool." It requires [Elasticsearch](http://www.elasticsearch.org/).
-
-1. Install [Elasticsearch](http://www.elasticsearch.org/) however you'd like. (We use [homebrew](http://brew.sh/).):
-	```
-	$ brew install elasticsearch
-	```
-
-2. Clone the sheer GitHub project to wherever you keep your projects (not inside Owning a Home):
-	```
-	$ git clone https://github.com/cfpb/sheer.git
-	```
-
-3. Create a virtualenv for sheer, which you'll name `OAH`:
-	```
-	$ mkvirtualenv OAH
-	```
-
-	The new virtualenv will activate right away. To activate it later on (say, in a new terminal session) use the command `workon OAH`. You'll know you have a virtual environment activated if you see the name of it in parentheses before your terminal prompt. Ex:
-	```
-	(OAH)username$
-	```
-
-	If the virtualenv did not activate right away, run this command from the directory above where the OAH directory lives:
-	```
-	$ source OAH/bin/activate
-	```
-
-	To deactivate, use the command `deactivate`.
-
-4. Install sheer into the virtualenv with the `-e` flag (which allows you to make changes to sheer itself). The path to sheer is the root directory of the GitHub repository you checked out (cloned) earlier, which likely will be `./sheer`:
-	```
-	$ pip install -e ~/path/to/sheer
-	```
-
-5. Install sheer's python requirements:
-	```
-	$ pip install -r ~/path/to/sheer/requirements.txt
-	```
-
-6. You should now be able to run the sheer command:
-	```
-	$ sheer
-	usage: sheer [-h] [--debug] {inspect,index,serve} …
-	sheer: error: too few arguments
-	```
-
-7. Populate Elasticsearch with content:
-  ```
-  $ [WORDPRESS=http://wordpress.uri] sheer index [--reindex]
-  ```
-  Make sure to be in the site's root folder and that Elasticsearch is running. The above
-  command will read all OaH content and save it in Elasticseach. [More information](#wordpress-indexing).
-
-If you run into problems or have any questions about Sheer, check out [Sheer on Github](https://github.com/cfpb/sheer) and the [Sheer Issue Tracker](https://github.com/cfpb/sheer/issues).
 
 ### Node, Grunt, Bower, Browserify
 
 1. Install [node.js](http://nodejs.org/), either v0.12 or io.js. If you're using the default version that comes with Mac OSX, you'll need to upgrade - first [install NVM](https://github.com/creationix/nvm).
 1. If you installed with NVM, then you can install and set io.js as your default node version:
-	```
-	$ nvm install iojs
-	$ nvm alias default iojs
+	```sh
+	nvm install iojs
+	nvm alias default iojs
 	```
 2. Install [Grunt](http://gruntjs.com/), [Bower](http://bower.io/) and [Browserify](http://browserify.org/):
-	```
-	$ npm install -g grunt-cli bower browserify
+	```sh
+	npm install -g grunt-cli bower browserify
 	```
 
 3. Navigate to the cloned `owning-a-home` directory and install the project's node dependencies:
-	```
-	$ npm install
+	```sh
+	npm install
 	```
 
 4. Navigate to the `config` folder. In that folder, copy the `example-config.json` file and rename it `config.json`. This can be done from the command line with the following two commands:
-	```
-	$ cd config
-	$ cp example-config.json config.json
+	```sh
+	cd config
+	cp example-config.json config.json
 	```
 
 5. Run grunt to build the site:
-	```
-	$ grunt
+	```sh
+	grunt
 	```
 
 [npm-shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) is used to lock down dependencies. If you add any dependencies to package.json, re-run `npm shrinkwrap` to generate a new `npm-shrinkwrap.json` file.
+
+### cfgov-refresh
+
+Owning a Home can be installed and run by the cfgov-refresh app.
+
+1. Clone the cfgov-refresh GitHub project to wherever you keep your projects (not inside Owning a Home):
+
+```sh
+git clone https://github.com/cfpb/sheer.git
+```
+
+2. Run all the [installation steps outlined in the cfgov-refresh](https://cfpb.github.io/cfgov-refresh/installation/) repo.
+
+3. In your window for cfgov-refresh, run the sheerlike command to pull in the pages that are still run by Sheer.
+
+```sh
+python cfgov/manage.py sheer_index
+```
+
+4. Run cfgov-refresh and navigate to the Owning a Home project in the browser.
 
 ## Configuration
 
@@ -138,17 +99,17 @@ If you run into problems or have any questions about Sheer, check out [Sheer on 
 To index your content from WordPress:
 
 1. In the repo directory, copy the `.env_SAMPLE` file and name it `.env`. This can be done from the command line with the following command:
-	```
-	$ cp .evn_SAMPLE .env
+	```sh
+	cp .evn_SAMPLE .env
 	```
 
 2. Add your WordPress URL in place of wordpress.domain on line 1 of `.env`.
 
 3. Run the following command inside the `/src/` or `/dist/` folder:
-	```
-	$ cd src
-	$ workon OAH
-	$ sheer index [--reindex]
+	```sh
+	cd src
+	workon OAH
+	sheer index [--reindex]
   ```
 
 


### PR DESCRIPTION
It turns out this project doesn't need Sheer anymore!

Instead, I reference the latest cfgov-refresh directions and explain how
to get Owning a Home working as a subdirectory of that project.

Thanks Serghei and @virginiacc for helping me debug that problem.