### PR TITLE
Editing more breadcrumbs

### DIFF
--- a/src/_layouts/loan_types_subpage_heading.html
+++ b/src/_layouts/loan_types_subpage_heading.html
@@ -1,10 +1,6 @@
-<!-- Back to loan types link and OAH Beta tag -->
-<div class="lt-subpage-header content-l">
-  <div class="col-6">
-    <a href="/owning-a-home/loan-options" class="go-back-link l-back-link">Understand loan options</a>
-  </div>
-
-  <div class="col-6 oah-title-right">
-    <h1 class="oah-title"><a href="/owning-a-home/">Owning a Home</a></h1>
-  </div>
-</div> <!-- /.wrapper -->
+<div class="content_wrapper content_wrapper__medium">
+    <nav class="breadcrumbs" aria-label="Breadcrumbs">
+      <a href="/owning-a-home/loan-options" class="breadcrumbs_link">Understand loan options</a>
+      <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
+    </nav>
+</div>

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
 
         </div>
         <div class="content-l_col content-l_col-1-3 hero-illu-inner">
-            <img class ="hero-illu" src="{{url_for('static', filename='img/hero-housekey.png')}}" alt="Illustration of house keys">
+            <img class="hero-illu" src="{{url_for('static', filename='img/hero-housekey.png')}}" alt="Illustration of house keys">
         </div> <!-- /.col-4 -->
       </div>
 

--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -6,15 +6,15 @@
 {% block content %}
 
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
-  <div class="content_wrapper content_wrapper__narrow">
-    <section class="content_main" id="fha">
-      {% include "loan_types_subpage_heading.html" %}
+  {% include "loan_types_subpage_heading.html" %}
 
+  <div class="content_wrapper content_wrapper__medium">
+    <section class="content_main" id="fha">
       <h2>FHA loans</h2>
 
       <div class="content-l">
         <section id="conventional-overview" class="col-9">
-          <p>FHA loans are loans from private lenders that are regulated and insured by the 
+          <p>FHA loans are loans from private lenders that are regulated and insured by the
           <a class="icon-link icon-link__external-link" href="http://portal.hud.gov/hudportal/HUD?src=/federal_housing_administration" target="_blank">
               <span class="icon-link_text">Federal Housing Administration</span>
             </a> (FHA), a government agency. The FHA doesn’t lend the money directly–private lenders do. FHA loans:</p>
@@ -51,7 +51,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../conventional-loans/">
               <span class="jump-link_text">Conventional loans</span>
@@ -70,7 +70,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link icon-link__external-link jump-link__bg" href="http://portal.hud.gov/hudportal/HUD?src=/federal_housing_administration" target="_blank">
               <span class="jump-link_text">Federal Housing Administration</span>
@@ -84,7 +84,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__bg" href="/askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html" target="_blank">
               <span class="jump-link_text">How can I find the loan limit for an FHA loan in my county?</span>
@@ -96,4 +96,3 @@
   </div>
 </main>
 {% endblock %}
-

--- a/src/loan-options/conventional-loans/index.html
+++ b/src/loan-options/conventional-loans/index.html
@@ -6,10 +6,10 @@
 {% block content %}
 
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
-  <div class="content_wrapper content_wrapper__narrow">
-    <section class="content_main">
-      {% include "loan_types_subpage_heading.html" %}
+  {% include "loan_types_subpage_heading.html" %}
 
+  <div class="content_wrapper content_wrapper__medium">
+    <section class="content_main">
       <h2>Conventional loan</h2>
 
       <div class="content-l">
@@ -96,7 +96,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../FHA-loans/">
               <span class="jump-link_text">FHA loans</span>
@@ -139,4 +139,3 @@
 </main>
 
 {% endblock %}
-

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -6,14 +6,13 @@
 {% block content %}
 
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
-  <div class="content_wrapper content_wrapper__narrow">
-    <section class="content_main">
-      {% include "loan_types_subpage_heading.html" %}
+  {% include "loan_types_subpage_heading.html" %}
 
+  <div class="content_wrapper content_wrapper__medium">
+    <section class="content_main">
       <h2>Special Loan Progams</h2>
 
       <p>For people who qualify, special loan programs can be more affordable than a <a href="../conventional-loans/" target="_blank">conventional</a> or <a href="../FHA-loans/" target="_blank">FHA</a> loan, so make sure to check to see if you are eligible. Always compare official loan offers, called <a href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">Loan Estimates</a>, before making a final decision.</p>
-
 
       <section class="loan-program" id="va">
         <h3 class="subheading">VA loan</h3>
@@ -21,7 +20,7 @@
         <div class="content-l">
           <div class="col-9">
 
-            <p>The 
+            <p>The
               <a class="icon-link icon-link__external-link" href="http://www.benefits.va.gov/homeloans/" target="_blank">
                 <span class="icon-link_text">Department of Veterans' Affairs (VA)</span>
               </a>
@@ -29,7 +28,7 @@
             <p>VA loans: </p>
             <ul>
               <li>Often offer low-cost, streamlined refinance options and additional protections if you have trouble paying your mortgage later on.</li>
-              <li>Do not require monthly mortgage insurance premiums, but usually require an 
+              <li>Do not require monthly mortgage insurance premiums, but usually require an
                 <a class="icon-link icon-link__external-link" href="http://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp" target="_blank">
                   <span class="icon-link_text">upfront fee</span>
                 </a>
@@ -53,7 +52,7 @@
         <div class="content-l">
           <div class="col-9">
 
-            <p>The 
+            <p>The
               <a class="icon-link icon-link__external-link" href="http://www.rurdev.usda.gov/had-guaranteed_housing_loans.html" target="_blank">
                 <span class="icon-link_text">US Department of Agriculture</span>
               </a>
@@ -87,7 +86,7 @@
 
             <p>Many programs offer down payment assistance that can be used with a regular <a href="../FHA-loans/" target="_blank">FHA</a> or <a href="../conventional-loans/" target="_blank">conventional loan</a>. Some programs lend money directly through subsidized loans. </p>
 
-            <p>If you think you might qualify, 
+            <p>If you think you might qualify,
             <a class="icon-link icon-link__external-link" href="http://downpaymentresource.com/" target="_blank">
                 <span class="icon-link_text">explore programs in your area using this tool</span>
               </a>
@@ -96,7 +95,7 @@
 
           <div class="col-3">
             <h4 class="small-heading">Mortgage insurance</h4>
-            <p class="sans">Required by <strong>many</strong> state and local programs.<br> 
+            <p class="sans">Required by <strong>many</strong> state and local programs.<br>
               <a href="#mortgage-insurance">More on mortgage insurance</a>.</p>
           </div>
 
@@ -120,7 +119,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../conventional-loans/">
               <span class="jump-link_text">Conventional loans</span>
@@ -139,7 +138,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link icon-link__external-link jump-link__bg" href="http://www.benefits.va.gov/homeloans/" target="_blank">
               <span class="jump-link_text">Department of Veterans' Affairs</span>
@@ -163,7 +162,7 @@
       </header>
 
       <div class="aside-chunk">
-        <ul class="list list__links list__spaced">  
+        <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__bg" href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">
               <span class="jump-link_text">What is a Loan Estimate?</span>
@@ -182,4 +181,3 @@
 </main>
 
 {% endblock %}
-

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -18,14 +18,14 @@
 {% set steps = query.search(size=100,q=filter) %}
 
 <main class="know-the-process wrapper" id="main" role="main">
+  <div class="content_wrapper content_wrapper__medium">
+      <nav class="breadcrumbs" aria-label="Breadcrumbs">
+        <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
+      </nav>
+  </div>
   <div>
 
     <section class="phase">
-      <div class="u-mb15">
-        <a class="list_link jump-link jump-link__left jump-link__before" href="/owning-a-home/">
-          Owning a Home
-        </a>
-      </div>
 
       {{ nav_macro.render("top", active_phase.slug) }}
 


### PR DESCRIPTION
Fixing up the breadcrumbs on the loan type and process pages to match
the rest of the site. These were actually newer and easier to update
than the first half in #678.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/18802609/d5c692fa-81b7-11e6-9bf9-b90f539a9fd9.png)

![image](https://cloud.githubusercontent.com/assets/1860176/18802621/e7c81a0a-81b7-11e6-8781-e7f94320a65f.png)


## Review

- @virginiacc 
