### PR TITLE
Add commas to explore rates tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,5 @@
     "tooltips": "./src/static/vendor/bootstrap/tooltip.js",
     "cf-button": "./src/static/vendor/cf-buttons/CFButton.jsx"
   },
- 
   "browserify-shim": "./config/shim.js"
-
 }

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -712,7 +712,6 @@ function renderDownPayment() {
   }
 
   checkIfZero( $price, $percent, $down );
-  addCommas( $el );
 
   if ( $price.val() !== 0 ) {
     if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
@@ -1198,7 +1197,6 @@ $( '.calc-loan-amt .recalc' ).on( 'keyup', function( evt ) {
 $( '.calc-loan-amt, .credit-score' ).on( 'keyup', '.recalc', function( evt ) {
   var verbotenKeys = [ 9, 37, 38, 39, 40 ];
   var element = this;
-
   // Don't recalculate on TAB or arrow keys.
   if ( verbotenKeys.indexOf( evt.which ) === -1 ||
        $( this ).hasClass( 'range' ) ) {
@@ -1206,6 +1204,8 @@ $( '.calc-loan-amt, .credit-score' ).on( 'keyup', '.recalc', function( evt ) {
       processLoanAmount( element );
     }, 500 );
   }
+
+  addCommas( $(evt.target) );
 } );
 
 // Once the user has edited fields, put the kibosh on the placeholders

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -712,6 +712,7 @@ function renderDownPayment() {
   }
 
   checkIfZero( $price, $percent, $down );
+  addCommas( $el );
 
   if ( $price.val() !== 0 ) {
     if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
@@ -720,6 +721,7 @@ function renderDownPayment() {
     } else {
       val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
       $down.val( val >= 0 ? Math.round( val ) : '' );
+      addCommas( $down );
     }
   }
 }
@@ -896,6 +898,17 @@ function removeCreditScoreAlert() {
     $( '.rangeslider__handle' ).removeClass( 'warning' );
     $( '.credit-alert' ).remove();
   }
+}
+
+/**
+ * Add commas to numbers where appropriate.
+ */
+
+function addCommas( $field ) {
+  var numberValue = $field.val();
+  numberValue = numberValue.toString().replace( ',', '' );
+  numberValue = formatUSD( numberValue, { decimalPlaces: 0 } ).replace( '$', '');
+  $field.val( numberValue );
 }
 
 /**

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -719,8 +719,9 @@ function renderDownPayment() {
       $percent.val( Math.round( val ) );
     } else {
       val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
-      $down.val( val >= 0 ? Math.round( val ) : '' );
-      addCommas( $down );
+      val = val >= 0 ? Math.round( val ) : '';
+      val = addCommas( val );
+      $down.val( val );
     }
   }
 }
@@ -901,14 +902,14 @@ function removeCreditScoreAlert() {
 
 /**
  * Add commas to numbers where appropriate.
- * @param {jQuery DOM Object} $field - jQuery field where commas will be added.
+ * @param {string} value - Old value where commas will be added.
+ * return {string} value - Value with commas and no dollar sign.
  */
-function addCommas( $field ) {
-  var numberValue = $field.val();
-  numberValue = numberValue.toString().replace( ',', '' );
-  numberValue = formatUSD( numberValue, { decimalPlaces: 0 } )
+function addCommas( value ) {
+  value = unFormatUSD( value );
+  value = formatUSD( value, { decimalPlaces: 0 } )
     .replace( '$', '' );
-  $field.val( numberValue );
+  return value;
 }
 
 /**
@@ -1207,8 +1208,11 @@ $( '.calc-loan-amt, .credit-score' ).on( 'keyup', '.recalc', function( evt ) {
   }
 } );
 
-$( '.calc-loan-amt, .credit-score' ).on( 'blur', '.recalc', function( evt ) {
-  addCommas( $( evt.target ) );
+$( '#house-price, #down-payment' ).on( 'focusout', function( evt ) {
+  var value;
+  value = $( evt.target ).val();
+  value = addCommas( value );
+  $( evt.target ).val( value );
 } );
 
 

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -901,12 +901,13 @@ function removeCreditScoreAlert() {
 
 /**
  * Add commas to numbers where appropriate.
+ * @param {jQuery DOM Object} $field - jQuery field where commas will be added.
  */
-
 function addCommas( $field ) {
   var numberValue = $field.val();
   numberValue = numberValue.toString().replace( ',', '' );
-  numberValue = formatUSD( numberValue, { decimalPlaces: 0 } ).replace( '$', '');
+  numberValue = formatUSD( numberValue, { decimalPlaces: 0 } )
+    .replace( '$', '' );
   $field.val( numberValue );
 }
 
@@ -1204,9 +1205,12 @@ $( '.calc-loan-amt, .credit-score' ).on( 'keyup', '.recalc', function( evt ) {
       processLoanAmount( element );
     }, 500 );
   }
-
-  addCommas( $(evt.target) );
 } );
+
+$( '.calc-loan-amt, .credit-score' ).on( 'blur', '.recalc', function( evt ) {
+  addCommas( $( evt.target ) );
+} );
+
 
 // Once the user has edited fields, put the kibosh on the placeholders
 $( '#house-price, #percent-down, #down-payment' ).on( 'keyup', function() {


### PR DESCRIPTION
This adds commas to the house price and downpayment field on refresh and
as people are typing.

## Testing

1. Visit http://localhost:8000/owning-a-home/explore-rates/
1. Type a five or six figure number for home price.
1. Change the downpayment as well.

## Review

-@virginiacc