### PR TITLE
Post-Review fixes for breadcrumbs

### DIFF
--- a/src/_layouts/loan_types_subpage_heading.html
+++ b/src/_layouts/loan_types_subpage_heading.html
@@ -1,6 +1,6 @@
-<div class="content_wrapper content_wrapper__medium">
+<div class="content_wrapper">
     <nav class="breadcrumbs" aria-label="Breadcrumbs">
-      <a href="/owning-a-home/loan-options" class="breadcrumbs_link">Understand loan options</a>
       <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
+      <a href="/owning-a-home/loan-options" class="breadcrumbs_link">Understand loan options</a>
     </nav>
 </div>

--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -5,13 +5,13 @@
 {% block title %}Owning a Home: Closing Disclosure Explainer{% endblock title %}
 {% block content %}
 <main class="content">
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
       <nav class="breadcrumbs" aria-label="Breadcrumbs">
         <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
       </nav>
   </div>
-  <div class="content_wrapper content_wrapper__medium">
-    <div class="form-explainer content_main {% if subnav %}col-9{% endif %}">
+  <div class="content_wrapper">
+    <div class="form-explainer content_main {% if subnav %}col-9{% endif %} u-pb0">
       <div class="page-intro content-l">
         <div class="content-l_col-2-3">
           <h1 class="page-title">Closing Disclosure Explainer</h1>

--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -6,15 +6,15 @@
 
 {% block content %}
 <main class="content">
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
     <nav class="breadcrumbs" aria-label="Breadcrumbs">
       <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
     </nav>
   </div>
 
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
 
-    <div class="content_main">
+    <div class="content_main u-pb0">
 
       <div class="rate-checker result {% if subnav %}col-9{% endif %}">
 
@@ -32,9 +32,9 @@
 
         <div class="calculator" aria-controls="rate-results">
 
-            <div class="form-intro">
+            <section class="form-intro">
                 <h4>Explore rate options</h4>
-            </div>
+            </section>
 
               <section class="credit-score">
                   <div class="range recalc">

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -5,16 +5,17 @@
 {% block title %}Owning a Home: Loan Estimate Explainer{% endblock title %}
 {% block content %}
 <main class="content">
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
       <nav class="breadcrumbs" aria-label="Breadcrumbs">
         <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
       </nav>
   </div>
 
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
     <div class="form-explainer
                 content_main
-                {% if subnav %}col-9{% endif %}">
+                {% if subnav %}col-9{% endif %}
+                u-pb0">
       <div class="page-intro content-l">
         <div class="content-l_col-2-3">
           <h1 class="page-title">Loan Estimate Explainer</h1>

--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -8,7 +8,7 @@
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
   {% include "loan_types_subpage_heading.html" %}
 
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
     <section class="content_main" id="fha">
       <h2>FHA loans</h2>
 

--- a/src/loan-options/conventional-loans/index.html
+++ b/src/loan-options/conventional-loans/index.html
@@ -8,7 +8,7 @@
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
   {% include "loan_types_subpage_heading.html" %}
 
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
     <section class="content_main">
       <h2>Conventional loan</h2>
 

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -5,17 +5,16 @@
 {% block title %}Owning a Home: Loan Options{% endblock title %}
 
 {% block content %}
-<main class="content">
-  <div class="content_wrapper content_wrapper__medium">
+<main class="content" id="main">
+  <div class="content_wrapper">
       <nav class="breadcrumbs" aria-label="Breadcrumbs">
         <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
       </nav>
   </div>
 
-  <div class="content_main content__1-3" id="main" role="main">
-    <div class="wrapper content_wrapper u-pb0">
-
-      <section class="content__loan-options content_main">
+  <div class="content_wrapper content__2-1">
+    <div class="content_main">
+      <section class="content__loan-options">
           <h1>Understand loan options</h1>
 
           <p class="lead">The kind of mortgage you choose has a big impact on how much you end up paying&mdash;how much you’ll have to pay upfront, your monthly payment amount, and the total cost of your loan over time. It also affects the level of risk you take on. Knowing what kind of loan is most appropriate for your situation prepares you for talking to lenders and getting the best deal.</p>
@@ -380,45 +379,46 @@
             </section> <!-- /.type-details -->
 
       </section>
-      <aside class="content_sidebar content__flush-all-on-small">
-      </aside>
-      {% import "related-links.html" as related_links %}
-      <div class="content_intro related-links_container">
-        {% set process_links = [
-            {
-              'desc': 'Still shopping for a home?',
-              'urls': [
-                {
-                  'label': 'Explore loan choices',
-                  'url': '/owning-a-home/process/explore/'
-                }
-              ]
-            },
-            {
-              'desc': 'Already have a home in mind?',
-              'urls': [
-                {
-                  'label': 'Compare loan offers',
-                  'url': '/owning-a-home/process/compare/'
-                }
-              ]
-            }
-         ] %}
-         {% set tools_links = [
-             {
-               'desc': 'Interest rates can differ based on the kind of loan you choose.',
-               'urls': [
-                {
-                  'label': 'Explore interest rates',
-                  'url': '/owning-a-home/explore-rates/'
-                }
-               ]
-             }
-          ] %}
-        {{ related_links.render(process_links, tools_links) }}
-      </div>
     </div>
   </div>
+
+  <aside class="content_wrapper content__flush-all-on-small">
+    {% import "related-links.html" as related_links %}
+    <div class="content_intro related-links_container">
+    {% set process_links = [
+        {
+          'desc': 'Still shopping for a home?',
+          'urls': [
+            {
+              'label': 'Explore loan choices',
+              'url': '/owning-a-home/process/explore/'
+            }
+          ]
+        },
+        {
+          'desc': 'Already have a home in mind?',
+          'urls': [
+            {
+              'label': 'Compare loan offers',
+              'url': '/owning-a-home/process/compare/'
+            }
+          ]
+        }
+     ] %}
+     {% set tools_links = [
+         {
+           'desc': 'Interest rates can differ based on the kind of loan you choose.',
+           'urls': [
+            {
+              'label': 'Explore interest rates',
+              'url': '/owning-a-home/explore-rates/'
+            }
+           ]
+         }
+      ] %}
+    {{ related_links.render(process_links, tools_links) }}
+  </div>
+  </aside>
 </main>
 
 {% endblock %}

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -8,7 +8,7 @@
 <main class="content content__2-1 content__bleedbar" id="main" role="main">
   {% include "loan_types_subpage_heading.html" %}
 
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
     <section class="content_main">
       <h2>Special Loan Progams</h2>
 

--- a/src/monthly-payment-worksheet/index.html
+++ b/src/monthly-payment-worksheet/index.html
@@ -7,14 +7,14 @@
 
 {% block content %}
 <main class="content">
-  <div class="content_wrapper content_wrapper__medium">
+  <div class="content_wrapper">
       <nav class="breadcrumbs" aria-label="Breadcrumbs">
         <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
       </nav>
   </div>
 
   <div id="monthly-payment" class="monthly-payment content_main" role="main">
-    <section class="content_wrapper content_wrapper__medium">
+    <section class="content_wrapper">
       <div class="content_main u-pb0">
         <div class="block block__flush-top monthly-payment_intro">
           <div class="content-l content-l__large-gutters">

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -17,12 +17,14 @@
 {% set filter = 'parent:' + id_str  %}
 {% set steps = query.search(size=100,q=filter) %}
 
-<main class="know-the-process wrapper" id="main" role="main">
-  <div class="content_wrapper content_wrapper__medium">
-      <nav class="breadcrumbs" aria-label="Breadcrumbs">
-        <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
-      </nav>
-  </div>
+<div class="content_wrapper">
+    <nav class="breadcrumbs" aria-label="Breadcrumbs">
+      <a href="/owning-a-home/" class="breadcrumbs_link">Owning a Home</a>
+    </nav>
+</div>
+
+<main class="know-the-process content_wrapper" id="main" role="main">
+
   <div>
 
     <section class="phase">

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -2,11 +2,11 @@
  a.jump-link,
  a.list_link {
    border-color: @link-underline;
-   
+
    &:visited {
      border-color: @link-underline-visited;
    }
-   
+
    &:hover {
      border-color: @link-underline-hover;
      z-index: 10;
@@ -84,11 +84,11 @@
 a.jump-link,
 a.list_link {
  border-color: @link-underline;
- 
+
  &:visited {
    border-color: @link-underline-visited;
  }
- 
+
  &:hover {
    border-color: @link-underline-hover;
    z-index: 10;
@@ -112,7 +112,7 @@ a.list_link {
 .char-icon {
   position: relative;
   padding-left: 1.5em;
- 
+
  &:before {
    position: absolute;
    left: 0;
@@ -159,7 +159,7 @@ a.list_link {
 /* Process-specific styles */
 
 .process-nav {
-  
+
   li {
     br {
       display: none;
@@ -169,40 +169,40 @@ a.list_link {
       background-color: @gray-5;
       border-color: @gray-5;
     }
-    
+
     .process-nav_step-number {
-      font-size: .85em; 
-      .phase_ordinal;       
+      font-size: .85em;
+      .phase_ordinal;
       background-color: @gray-10;
-      
+
       .respond-to-min(@tablet-min, {
         float: none;
         display: block;
         margin: 0 auto .5em;
       });
     }
-    
+
     &.current-step .process-nav_step-number {
       background-color: @green-tint;
     }
   }
-  
+
   .respond-to-max(@mobile-max, {
     .jump-link {
       border-top: 1px solid @gray-50;
       border-bottom: 1px solid @gray-50;
       margin-bottom: -1px;
-      
+
       &:after {
         content: "\e002";
       }
     }
-    
+
     li {
       .process-nav_step-contents {
         padding-left: @grid_gutter-width/2;
       }
-      
+
       &.process-nav_header {
         .process-nav_step-contents {
           .h6;
@@ -214,15 +214,15 @@ a.list_link {
 
       &.current-step {
         border-left: 5px solid @green;
-        
+
         .process-nav_step-contents {
           padding-left: @grid_gutter-width/3;
         }
       }
     }
-    
+
   });
-  
+
   a.process-nav_step-contents {
     &:visited {
       border-color: @link-underline;
@@ -238,7 +238,7 @@ a.list_link {
       }
     }
   }
-  
+
   .respond-to-min(@tablet-min, {
     width: 100%;
     position: relative;
@@ -247,7 +247,7 @@ a.list_link {
     span {
       display: block;
     }
-    
+
     li {
       .webfont-medium();
       display: table-cell;
@@ -255,7 +255,7 @@ a.list_link {
       text-align: center;
       border-top: 1px solid @gray-50;
       border-bottom: 1px solid @gray-50;
-      
+
       .process-nav_step-contents {
         display: block;
         position: static;
@@ -269,16 +269,16 @@ a.list_link {
           margin-bottom: @grid_gutter-width/3;
         }
       }
-      
+
       &.step-1 .process-nav_step-contents:before {
         width: 0;
       }
-      
+
       br {
         display: block;
       }
     }
-    
+
     &.process-nav__top {
       li {
         &.current-step {
@@ -288,16 +288,16 @@ a.list_link {
           position: relative;
           top: -1px;
         }
-        
+
         &.process-nav_header,
         &.step-1 {
           padding-top: @grid_gutter-width * 2/3;
           padding-bottom: @grid_gutter-width * 2/3;
           position: relative;
-          
+
           .process-nav_step-contents {
             padding: 0;
-            
+
             &:before {
               width: 5px;
               background-color: white;
@@ -306,7 +306,7 @@ a.list_link {
             }
           }
         }
-        
+
         &.process-nav_header {
           border-width: 0;
           text-align: left;
@@ -318,11 +318,11 @@ a.list_link {
               right: 0;
             }
           }
-        }          
+        }
       }
     }
-  }); 
-  
+  });
+
   &__top {
     li {
       .respond-to-min(@tablet-min, {
@@ -338,7 +338,7 @@ a.list_link {
       }
     });
   }
-  
+
 }
 
 .know-the-process {
@@ -346,7 +346,7 @@ a.list_link {
   .intro {
     .webfont-medium();
   }
-  
+
   .tools-col {
     .respond-to-max(799px, {
       margin-right: -(@grid_gutter-width / 2);
@@ -360,14 +360,14 @@ a.list_link {
       margin-top: @grid_gutter-width;
     }
   }
-  
+
   .tools {
     background-color: @green-tint;
     .respond-to-max(799px, {
       margin-top: 0px;
     });
   }
-    
+
   .steps-col {
     .respond-to-range(600px, 799px, {
       .grid_column(12);
@@ -378,18 +378,18 @@ a.list_link {
       margin-top: 0;
     });
   }
-  
+
   .step {
     h2 {
       .h4;
       margin-bottom: @grid_gutter-width / 3;
       margin-top: @grid_gutter-width;
     }
-    
+
     .content-l_col h2:first-child {
       margin-top: 0px;
     }
-    
+
     ul {
       padding-left: 20px;
     }
@@ -401,13 +401,13 @@ a.list_link {
       .custom-bullet(@text:"\25AA", @color: @list__branded-bullet, @offset: @offset, @size: @size);
       .list_item__spaced;
     }
-    
+
     li.alert {
       &:before {
         top: 2px;
       }
     }
-    
+
     li.action {
       .checked;
       &:before {
@@ -415,7 +415,7 @@ a.list_link {
       }
     }
   }
-  
+
   .expandable-group {
       border-top: 1px solid @gray-80;
       .content-l__main {
@@ -430,10 +430,10 @@ a.list_link {
           });
         }
         .content-l_col-2-3 + .content-l_col-1-3  {
-            margin-top: 0;  
+            margin-top: 0;
         }
         .content-l_col-1-4 + .content-l_col-3-4  {
-            margin-top: 0;  
+            margin-top: 0;
         }
       }
       .list__branded li {
@@ -448,13 +448,13 @@ a.list_link {
           .u-mb45;
         });
       }
-      
+
   }
 
   .expandable_label {
     width: 90%;
   }
-  
+
   .expandable_cue_text {
     border-bottom: 1px dotted @link-underline;
   }
@@ -479,14 +479,14 @@ a.list_link {
       margin-left: 3px;
     }
   }
-  
+
   .phase_number {
     font-size: .6em;
     .phase_ordinal;
     position: relative;
     top: .25em;
   }
-  
+
   .milestones {
     &_header {
       padding-left: 1.25em;
@@ -494,7 +494,7 @@ a.list_link {
     .respond-to-min(800px, {
       border-bottom: 1px solid @gray-50;
     });
-    
+
     ul {
       padding-left: 20px;
       list-style-type: none;
@@ -506,38 +506,28 @@ a.list_link {
           .custom-bullet(@text:"\25AA", @color: @list__branded-bullet, @offset: @offset, @size: @size);
         }
       });
-      
+
       .respond-to-min(800px, {
         padding-left: 0;
       });
     }
   }
-  
+
   .phase_data {
     margin-bottom: @grid_gutter-width;
-    
+
     .tools {
       margin-bottom: @grid_gutter-width;
     }
-    
+
     .respond-to-min(800px, {
       .block;
-      
+
       .tools {
         margin-bottom: 0;
       }
     });
   }
-
-  &.wrapper {
-    margin: 0 auto !important;
-    max-width: 1100px;
-    
-    .respond-to-min(800px, {
-      padding-top: @grid_gutter-width;
-    });
-  }
-  
 }
 
 .sources-step {


### PR DESCRIPTION
- Made the switch from content-wrapper__medium to content-wrapper to
  make sure it matches the new grid completely
- Switched breadcrumbs on loan option type pages
- Removed CSS that was for the old grid
- Double checked to make sure the sidefoot shaded grid is always flush with the bottom border

## Review
- @virginiacc 