### PR TITLE
Chart Tweaks on /explore-rates/

### DIFF
--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -255,7 +255,7 @@
               </table>
             </div>
 
-            <section id="chart-section" class="chart wrapper">
+            <section id="chart-section" class="chart">
               <figure class="data-enabled loading">
                 <div id="chart" class="chart-area"></div>
                 <figcaption class="chart-caption">

--- a/src/static/css/module/explore-rates.less
+++ b/src/static/css/module/explore-rates.less
@@ -121,10 +121,10 @@
   }
 }
 
-.loan-amt-total, 
+.loan-amt-total,
 .state-col {
   border-width: 0;
-  
+
   .wrapper {
     padding: 0;
   }
@@ -289,12 +289,22 @@
 
 .data-label {
   text-align: center;
+}
+
+.data-label_number {
   background-color: #fff;
+  .respond-to-max(@mobile-max, {
+    display: block;
+    transform: rotate(-90deg);
+  });
 }
 
 .chart-caption {
   font-size: 1em;
-  padding: 0 1em 1em 1em;
+  padding-bottom: 1em;
+  padding-right: 1em;
+  // Magic number to line up caption with chart
+  margin-left: 60px;
 }
 
 .caption-title {
@@ -334,7 +344,7 @@
     font-size: 3em;
     max-width: 30%;
     text-align: right;
-    
+
   }
   .text {
     display: inline-block;

--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -1021,7 +1021,6 @@ function renderChart( data, cb ) {
         max: 10,
         min: 0
       }, {
-        opposite: true,
         title: {
           text: 'Number of lenders offering rate'
         }
@@ -1049,7 +1048,7 @@ function renderChart( data, cb ) {
                 } );
               }
             } );
-            return '<div class="data-label">' + this.x + '<br>|</div>';
+            return '<div class="data-label"><span class="data-label_number">' + this.x + '</span><br>|</div>';
           }
         }
       } ],

--- a/src/static/js/modules/highcharts-theme.js
+++ b/src/static/js/modules/highcharts-theme.js
@@ -8,7 +8,6 @@ Highcharts.theme = {
   },
   chart: {
     backgroundColor: '#FFFFFF',
-    marginLeft:      30,
     marginRight:     25
   },
   yAxis: {
@@ -26,8 +25,7 @@ Highcharts.theme = {
         fontSize:   '16px',
         fontWeight: 'normal',
         fontFamily: '"Avenir Next", Arial, sans-serif'
-      },
-      rotation: 450
+      }
     },
     plotLines: [ {
       color:  '#919395',
@@ -55,6 +53,11 @@ Highcharts.theme = {
     backgroundColor: 'transparent',
     borderColor:     'none',
     shadow:          false
+  },
+  plotOptions: {
+    series: {
+      groupPadding: 0.08
+    }
   }
 };
 


### PR DESCRIPTION
Worked with @amycesal to make a few improvements to the charts:
- On mobile, the labels are rotated to allow for better readability
- Moved the labels so they are grouped together on the y-axis
- Changed the spacing between the bars to avoid zebra-striping effect

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/19133258/5b9ab89a-8b25-11e6-8a2b-7f0df4bc8635.png)

## Review
- @mthibos 
- @virginiacc 

