### PR TITLE
Additional Print Styles

### DIFF
--- a/src/static/css/module/explore-rates.less
+++ b/src/static/css/module/explore-rates.less
@@ -10,6 +10,21 @@
     }
 }
 
+@media (max-width: 720px) {
+  .rc-home-illu {
+    display: none;
+  }
+  .rc-illu-inner {
+    padding: 0;
+  }
+}
+
+@media print {
+  .rc-illu-inner {
+    display: none;
+  }
+}
+
 .rc-illu-inner {
   padding: 1em 4.5em 0 4.5em;
 }
@@ -36,6 +51,13 @@
   }
 }
 
+@media print {
+  .calculator,
+  .rc-results {
+    .grid_column( 12 );
+    .grid_push( 0 );
+  }
+}
 /*
     Sidebar with all the user input
     --------------------------- */
@@ -121,10 +143,10 @@
   }
 }
 
-.loan-amt-total, 
+.loan-amt-total,
 .state-col {
   border-width: 0;
-  
+
   .wrapper {
     padding: 0;
   }
@@ -145,6 +167,13 @@
   font-size: 0.875em;
   text-align: right;
   margin-right: 1.25em; //align it nicely with the chart
+}
+
+@media print {
+  .calculator section {
+    width: 100%;
+    display: inline-block;
+  }
 }
 
 /*
@@ -241,6 +270,13 @@
   text-align: center;
 }
 
+@media print {
+  .rangeslider,
+  .credit-score .labels {
+    display: none;
+  }
+}
+
 /*
     Main section with output
     --------------------------- */
@@ -334,7 +370,7 @@
     font-size: 3em;
     max-width: 30%;
     text-align: right;
-    
+
   }
   .text {
     display: inline-block;

--- a/src/static/css/module/form-resources.less
+++ b/src/static/css/module/form-resources.less
@@ -142,4 +142,9 @@
 
     }
 
+    @media print {
+        .hero_img-container {
+            display: none
+        }
+    }
 } //.form-resources

--- a/src/static/css/module/index.less
+++ b/src/static/css/module/index.less
@@ -77,22 +77,22 @@
   text-align: center;
 }
 
-// Phases for Journey 
+// Phases for Journey
 .section__phase {
   .content-l_col {
     margin-top: 0;
   }
 }
-  
+
   .content-l_col {
     &.content-l_col-1-4  {
       .respond-to-min(@tablet-min, {
-        .grid_column(1, 4);    
+        .grid_column(1, 4);
       });
     }
     &.content-l_col-3-4  {
       .respond-to-min(@tablet-min, {
-        .grid_column(3, 4);    
+        .grid_column(3, 4);
       });
     }
   }
@@ -100,7 +100,7 @@
   .content-l__main {
     .content-l_col-1-4 + .content-l_col-3-4  {
       .respond-to-min(@tablet-min, {
-        margin-top: 0;  
+        margin-top: 0;
       });
     }
   }
@@ -114,7 +114,7 @@
   .phase_tools {
     position: relative;
   }
-  
+
   .respond-to-max(@mobile-max, {
     .phase_illu {
       text-align: center;
@@ -144,7 +144,7 @@
   }
 }
 
-#email{
+#email {
   width: 200px;
 }
 
@@ -155,13 +155,11 @@ fieldset.submit_btn > p {
   padding:0px;
 }
 
-.input-with-btn > div{display: inline-block;}
-
-@media (max-width: 720px) {
-  .rc-home-illu {
-    display: none;
-  }
+.input-with-btn > div {
+  display: inline-block;
 }
 
+
 .tabbed-pad-top {
-  margin-top: @grid_gutter-width;}
+  margin-top: @grid_gutter-width;
+}

--- a/src/static/css/module/print.less
+++ b/src/static/css/module/print.less
@@ -37,6 +37,7 @@
    ========================================================================== */
 
 @media print {
+
   *,
   *:before,
   *:after {
@@ -53,9 +54,8 @@
     border-bottom: 0;
   }
 
-  a[href]:after {
+  #main a[href]:after {
     content: " (" attr(href) ")";
-    display: block;
     position: relative;
     top: 0;
     left: 0;
@@ -65,6 +65,7 @@
     width: auto;
     word-wrap: break-word;
     white-space: normal;
+    text-align: inherit;
   }
 
   abbr[title]:after {
@@ -76,8 +77,8 @@
    * or use the `javascript:` pseudo protocol
    */
 
-  a[href^="#"]:after,
-  a[href^="javascript:"]:after {
+  #main a[href^="#"]:after,
+  #main a[href^="javascript:"]:after {
     content: "";
   }
 
@@ -116,64 +117,88 @@
   h3 {
     page-break-after: avoid;
   }
-}
 
-/* topdoc
-  name: Hero image print styles
-  family: cfgov-cf-enhancements
-  patterns:
-    - name: #hero-bg-image
-      markup: |
-        <div class="wrapper hero-wrapper">
-          <div class="col-7">
-            <h1>Owning a Home</h1>
-            <h2>We’re here to help you with your home buying process. Just starting out? Learn what to expect and how to get a great deal. About to close? A checklist makes it less stressful.</h2>
+  #skip-nav {
+    display: none;
+  }
+
+  .content-l_col {
+    width: 100%
+  }
+
+  .process-nav .jump-link,
+  .jump-link.jump-link__block {
+    border: 0;
+    padding: 0;
+  }
+
+  /* topdoc
+    name: Hero image print styles
+    family: cfgov-cf-enhancements
+    patterns:
+      - name: #hero-bg-image
+        markup: |
+          <div class="wrapper hero-wrapper">
+            <div class="col-7">
+              <h1>Owning a Home</h1>
+              <h2>We’re here to help you with your home buying process. Just starting out? Learn what to expect and how to get a great deal. About to close? A checklist makes it less stressful.</h2>
+            </div>
           </div>
-        </div>
-  tags:
-    - cfgov-cf-enhancements
-*/
+    tags:
+      - cfgov-cf-enhancements
+  */
 
-#hero-bg-image {
-  .respond-to-print({
-    background-image: none; 
+  #hero-bg-image {
+    background-image: none;
     background-color: transparent;
     border-bottom: 1px solid @gray-50;
-  });
-}
+  }
 
-/* topdoc
-  name: PDF Link print styles
-  family: cfgov-cf-enhancements
-  patterns:
-    - name: .superheader
-      markup: |
-        <a class="pdf-link pdf" href="/owning-a-home/resources/checklist_mortgage_closing.pdf">Get the closing checklist</a>
-  tags:
-    - cfgov-cf-enhancements
-*/
+  /* topdoc
+    name: PDF Link print styles
+    family: cfgov-cf-enhancements
+    patterns:
+      - name: .superheader
+        markup: |
+          <a class="pdf-link pdf" href="/owning-a-home/resources/checklist_mortgage_closing.pdf">Get the closing checklist</a>
+    tags:
+      - cfgov-cf-enhancements
+  */
 
-.pdf-link {
-  .respond-to-print({
+  .pdf-link {
     display: inline;
-  });
-}
+  }
 
-/* topdoc
-  name: Header slug print styles
-  family: cfgov-cf-enhancements
-  patterns:
-    - name: .tabbed-heading
-      markup: |
-        <header class="tabbed-header tabbed-pad-top">
-        <h3 class="subhead tabbed-heading">Stay tuned</h3>
-      </header>
-  tags:
-    - cfgov-cf-enhancements
-*/
+  /* topdoc
+    name: Header slug print styles
+    family: cfgov-cf-enhancements
+    patterns:
+      - name: .tabbed-heading
+        markup: |
+          <header class="tabbed-header tabbed-pad-top">
+          <h3 class="subhead tabbed-heading">Stay tuned</h3>
+        </header>
+    tags:
+      - cfgov-cf-enhancements
+  */
 
-.tabbed-heading {
-  .respond-to-print({
+  .tabbed-heading {
     border-top-color: @gray-50;
-  });
+  }
+
+  .o-footer {
+    .list_link {
+      border: 0;
+      padding: 0;
+    }
+
+    .o-footer_pre {
+      margin-bottom: 0;
+    }
+
+    .o-footer_official-website {
+      background: none;
+      padding-left: 0;
+    }
+  }
 }


### PR DESCRIPTION
Made some adjustments on print styles to reduce the number of pages being printed.

Since Chrome prints with mobile styles and Firefox/IE prints on desktop styles, the styles need to be flexible enough to work with both.

These aren't perfect, but they're a huge improvement, especially for Firefox/IE where a lot of text was being cut off.

## Testing
- Review and Print Preview the following pages:
  - http://localhost:8000/owning-a-home/explore-rates/
  - http://localhost:8000/owning-a-home/closing-disclosure/
  - http://localhost:8000/owning-a-home/loan-options/
  - http://localhost:8000/owning-a-home/loan-options/FHA-loans
  - http://localhost:8000/owning-a-home/process
