### PR TITLE
Add Social Media Icons

### DIFF
--- a/src/_layouts/social-media.html
+++ b/src/_layouts/social-media.html
@@ -1,0 +1,190 @@
+{# ==========================================================================
+
+   social_media.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates markup for Social Media molecule.
+
+   value:                   Object of optional parameters.
+
+   value.blurb:             Sets the text of a tweet, the subject of an email,
+                            or the title of a LinkedIn post.
+                            Default is "Look what I found on the CFPB's site!"
+
+   value.is_share_view:     Whether the "Share this" heading is shown.
+                            Default is true.
+
+   value.twitter_hashtags:  A comma-separated list of hashtags
+                            to be appended to default Tweet text.
+                            https://dev.twitter.com/web/tweet-button/parameters
+
+   value.twitter_related:   A comma-separated list of accounts
+                            related to the content of the shared URI.
+                            https://dev.twitter.com/web/tweet-button/parameters
+                            Default is `cfpb`.
+
+   value.twitter_lang:      Loads text components in the specified language,
+                            if other than English.
+                            https://dev.twitter.com/web/tweet-button/parameters
+
+   ========================================================================== #}
+
+{% macro render( value={} ) %}
+
+{% set blurb = (value.blurb or (page.seo_title if page) or value.title or
+                'Look what I found on the CFPB’s site!') | urlencode %}
+{% set parsed_url = request.url | urlencode %}
+{% set external_redirect_url = '/external-site/?ext_url=' %}
+{% set is_share_view = value.is_share_view | default( true ) %}
+
+<div class="m-social-media
+            m-social-media__{{ 'share' if is_share_view else 'follow' }}">
+    {% if is_share_view %}
+        <div class="h5 m-social-media_heading">Share this</div>
+        <div class="h5 m-social-media_heading m-social-media_heading__es">Compartir este</div>
+    {% endif %}
+
+    <ul class="list
+               list__unstyled
+               list__horizontal
+               m-social-media_icons">
+
+        {% set facebook_info = {
+            'name': 'Facebook',
+            'homepage': 'https://facebook.com/cfpb',
+            'share_url': 'https://www.facebook.com/dialog/share?app_id=210516218981921&display=page&href=' ~ parsed_url ~ '&redirect_uri=' ~ parsed_url,
+            'class': 'cf-icon-facebook-square'
+        } %}
+
+        {% set twitter_info = {
+            'name': 'Twitter',
+            'homepage': 'https://twitter.com/cfpb',
+            'share_url': _share_twitter_url(parsed_url, blurb, value),
+            'class': 'cf-icon-twitter-square'
+        } %}
+
+        {% set linkedin_info = {
+            'name': 'LinkedIn',
+            'homepage': 'https://www.linkedin.com/company/consumer-financial-protection-bureau',
+            'share_url': 'https://www.linkedin.com/shareArticle?mini=true&url=' ~ parsed_url ~ '&title=' ~ blurb,
+            'class': 'cf-icon-linkedin-square'
+        } %}
+
+        {% set email_info = {
+            'name': 'email',
+            'share_url': 'mailto:?subject=' ~ blurb ~ '&body=Check out this page from the CFPB - ' ~ parsed_url,
+            'class': 'cf-icon-email-social-square'
+        } %}
+
+        {% set youtube_info = {
+            'name': 'YouTube',
+            'homepage': 'https://www.youtube.com/user/cfpbvideo',
+            'class': 'cf-icon-youtube-square'
+        } %}
+
+        {% set flickr_info = {
+            'name': 'Flickr',
+            'homepage': 'https://www.flickr.com/photos/cfpbphotos',
+            'class': 'cf-icon-flickr-square'
+        } %}
+
+        {% if is_share_view %}
+            {% set links = [
+                facebook_info,
+                twitter_info,
+                linkedin_info,
+                email_info
+            ] %}
+        {% else %}
+            {% set links = [
+                facebook_info,
+                twitter_info,
+                linkedin_info,
+                youtube_info,
+                flickr_info
+            ] %}
+        {% endif %}
+
+
+        {% for link in links %}
+            {% if is_share_view %}
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="{{ external_redirect_url ~ link.share_url if link.name != 'email'
+                                else link.share_url | trim }}"
+                       {{ 'target=_blank' if link.name != 'email' else '' }}>
+                        <span class="cf-icon {{ link.class }}"></span>
+                        <span class="u-visually-hidden">Share on {{ link.name }}</span>
+                    </a>
+                </li>
+            {% else %}
+                <li class="list_item">
+                    <a class="m-social-media_icon"
+                       href="{{ external_redirect_url ~ link.homepage | trim }}">
+                        <span class="cf-icon {{ link.class }}"></span>
+                        <span class="u-visually-hidden">Visit us on {{ link.name }}</span>
+                    </a>
+                </li>
+            {% endif %}
+        {% endfor %}
+
+    </ul>
+</div>
+{% endmacro %}
+
+{# ==========================================================================
+
+   _share_twitter_url()
+
+   ==========================================================================
+
+   Description:
+
+   Returns a Twitter share URL when given:
+
+   parsed_url:               URL-encoded URL.
+
+   blurb:                    Suggested text for the tweet.
+
+   options:                  Object of optional parameters.
+
+   options.twitter_hashtags: (Optional) A comma-separated list of hashtags
+                             to be appended to default Tweet text.
+                             https://dev.twitter.com/web/tweet-button/parameters
+
+   options.twitter_related:  (Optional) A comma-separated list of accounts
+                             related to the content of the shared URI.
+                             https://dev.twitter.com/web/tweet-button/parameters
+                             Default is `cfpb`.
+
+   options.twitter_lang:     (Optional) Loads text components in the specified
+                             language, if other than English.
+                             https://dev.twitter.com/web/tweet-button/parameters
+
+   ========================================================================== #}
+
+{% macro _share_twitter_url(parsed_url, blurb, options) %}
+    {%- set _share_twitter_url = 'http://twitter.com/intent/tweet' -%}
+    {%- set _share_twitter_url = _share_twitter_url + '?url=' + parsed_url -%}
+    {%- set _share_twitter_url = _share_twitter_url + '&via=CFPB' -%}
+    {%- set _share_twitter_url = _share_twitter_url + '&text=' + blurb + '%20--' -%}
+
+    {%- if options.twitter_hashtags %}
+        {% set _share_twitter_url = _share_twitter_url + '&hashtags=' + options.twitter_hashtags %}
+    {% endif -%}
+
+    {%- if options.twitter_related %}
+        {% set _share_twitter_url = _share_twitter_url + '&related=' + options.twitter_related %}
+    {%- else %}
+        {% set _share_twitter_url = _share_twitter_url + '&related=cfpb' %}
+    {% endif -%}
+
+    {%- if options.twitter_lang %}
+        {% set _share_twitter_url = _share_twitter_url + '&lang=' + options.twitter_lang %}
+    {% endif -%}
+
+    {{ _share_twitter_url }}
+{% endmacro %}

--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -21,7 +21,7 @@
                       block__flush-top
                       block__padded-top
                       block__flush-bottom
-                      u-right">
+                      u-right-on-desktop">
             {{ social_media.render( {
                   'title':  'Check out this page from the @CFPB'
             } ) }}

--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "closing-disclosure" %}
 {% set page_js = "closing-disclosure" %}
 
@@ -16,6 +17,15 @@
         <div class="content-l_col-2-3">
           <h1 class="page-title">Closing Disclosure Explainer</h1>
           <p class="lead">Lenders are required to provide your Closing Disclosure three business days before your scheduled closing. Use these days wisely. This tool will help you double-check that all the details are correct. If something looks different from what you expected, ask why. Now is the time to resolve problems&mdash;if the explanation you get isn’t satisfactory, keep asking questions.</p>
+          <div class="block
+                      block__flush-top
+                      block__padded-top
+                      block__flush-bottom
+                      u-right">
+            {{ social_media.render( {
+                  'title':  'Check out this page from the @CFPB'
+            } ) }}
+          </div>
         </div>
 
         <div class="content-l_col-1-3">

--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "explore-rates" %}
 {% set page_js = "explore-rates" %}
 
@@ -22,6 +23,15 @@
           <div class="content-l_col content-l_col-2-3">
             <h2 class="page-title">Explore interest rates<sup class="beta">BETA</sup></h2>
             <p class="lead">Our data comes from actual lenders and is updated every day. Credit score, loan type, home price, and down payment amount all affect the interest rate you can get. Interest is only one of the many costs you will pay when getting a mortgage. While shopping, ask about <a href="/askcfpb/136/what-are-discount-points-or-points.html" target="_blank">points</a>, <a href="/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html" target="_blank">mortgage insurance</a>, and <a href="/askcfpb/139/what-are-closing-costs.html" target="_blank">closing costs</a>. Make a final decision only after comparing lenders’ <a href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">Loan Estimates</a> which include all the costs.</p>
+            <div class="block
+                        block__flush-top
+                        block__padded-top
+                        block__flush-bottom
+                        u-right">
+              {{ social_media.render( {
+                    'title':  'Check out this page from the @CFPB'
+              } ) }}
+            </div>
           </div>
           <div class="content-l_col content-l_col-1-3">
             <div class="rc-illu-inner">

--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -27,7 +27,7 @@
                         block__flush-top
                         block__padded-top
                         block__flush-bottom
-                        u-right">
+                        u-right-on-desktop">
               {{ social_media.render( {
                     'title':  'Check out this page from the @CFPB'
               } ) }}

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-estimate" %}
 {% set page_js = "loan-estimate" %}
 
@@ -20,6 +21,15 @@
         <div class="content-l_col-2-3">
           <h1 class="page-title">Loan Estimate Explainer</h1>
           <p class="lead">When you receive a Loan Estimate, it should reflect a particular loan you discussed with a lender. Check to see that everything matches your expectations. If something looks different from what you expected, ask why. This tool will help you review your Loan Estimate and get definitions for unfamiliar terms.</p>
+          <div class="block
+                      block__flush-top
+                      block__padded-top
+                      block__flush-bottom
+                      u-right">
+            {{ social_media.render( {
+                  'title':  'Check out this page from the @CFPB'
+            } ) }}
+          </div>
         </div>
         <div class="content-l_col-1-3">
             <img src="{{ static('owning-a-home/static/img/ill-form-explainer-loan-est.png') }}" alt="" class="illustration">

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -25,7 +25,7 @@
                       block__flush-top
                       block__padded-top
                       block__flush-bottom
-                      u-right">
+                      u-right-on-desktop">
             {{ social_media.render( {
                   'title':  'Check out this page from the @CFPB'
             } ) }}

--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -53,11 +53,12 @@
               'title':  'Check out this page from the @CFPB'
         } ) }}
       </div>
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Other loan types</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">
+            Other loan types
+          </span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../conventional-loans/">
@@ -72,11 +73,12 @@
         </ul>
       </div>
 
-        <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Related links</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">
+            Related links
+          </span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link icon-link__external-link jump-link__bg" href="http://portal.hud.gov/hudportal/HUD?src=/federal_housing_administration" target="_blank">
@@ -86,11 +88,10 @@
         </ul>
       </div>
 
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Ask CFPB</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Ask CFPB</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__bg" href="/askcfpb/1963/how-can-i-find-the-loan-limit-for-an-fha-loan-in-my-county.html" target="_blank">
@@ -99,6 +100,7 @@
           </li>
         </ul>
       </div>
+
     </aside>
   </div>
 </main>

--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options-subpage" %}
 
 {% block title %}Owning a Home: Loan Options{% endblock title %}
@@ -46,6 +47,12 @@
     </section> <!-- /.content_main -->
 
     <aside class="content_sidebar sans">
+      <div class="block
+                  block__flush-top">
+        {{ social_media.render( {
+              'title':  'Check out this page from the @CFPB'
+        } ) }}
+      </div>
       <header class="tabbed-header">
         <h3 class="subhead tabbed-heading">Other loan types</h3>
       </header>

--- a/src/loan-options/conventional-loans/index.html
+++ b/src/loan-options/conventional-loans/index.html
@@ -90,7 +90,6 @@
 
     </section> <!-- /content_main -->
 
-
     <aside class="content_sidebar sans">
       <div class="block
                   block__flush-top">
@@ -98,11 +97,10 @@
               'title':  'Check out this page from the @CFPB'
         } ) }}
       </div>
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Other loan types</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Other loan types</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../FHA-loans/">
@@ -116,12 +114,10 @@
           </li>
         </ul>
       </div>
-
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Ask CFPB</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Ask CFPB</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__bg" href="/askcfpb/1959/what-are-fannie-mae-and-freddie-mac.html" target="_blank">

--- a/src/loan-options/conventional-loans/index.html
+++ b/src/loan-options/conventional-loans/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options-subpage" %}
 
 {% block title %}Owning a Home: Loan Options{% endblock title %}
@@ -91,6 +92,12 @@
 
 
     <aside class="content_sidebar sans">
+      <div class="block
+                  block__flush-top">
+        {{ social_media.render( {
+              'title':  'Check out this page from the @CFPB'
+        } ) }}
+      </div>
       <header class="tabbed-header">
         <h3 class="subhead tabbed-heading">Other loan types</h3>
       </header>

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -23,8 +23,8 @@
         <div class="block
                     block__flush-top
                     block__flush-bottom
-                    block__padded-bottom"
-             style="text-align: right">
+                    block__padded-bottom
+                    social-media_container">
           {{ social_media.render( {
                 'title':  'Check out this page from the @CFPB'
           } ) }}

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options" %}
 {% set page_js = "loan-options" %}
 
@@ -15,9 +16,19 @@
   <div class="content_wrapper content__2-1">
     <div class="content_main">
       <section class="content__loan-options">
-          <h1>Understand loan options</h1>
+        <h1>Understand loan options</h1>
 
-          <p class="lead">The kind of mortgage you choose has a big impact on how much you end up paying&mdash;how much you’ll have to pay upfront, your monthly payment amount, and the total cost of your loan over time. It also affects the level of risk you take on. Knowing what kind of loan is most appropriate for your situation prepares you for talking to lenders and getting the best deal.</p>
+        <p class="lead">The kind of mortgage you choose has a big impact on how much you end up paying&mdash;how much you’ll have to pay upfront, your monthly payment amount, and the total cost of your loan over time. It also affects the level of risk you take on. Knowing what kind of loan is most appropriate for your situation prepares you for talking to lenders and getting the best deal.</p>
+
+        <div class="block
+                    block__flush-top
+                    block__flush-bottom
+                    block__padded-bottom"
+             style="text-align: right">
+          {{ social_media.render( {
+                'title':  'Check out this page from the @CFPB'
+          } ) }}
+        </div>
 
             <div class="subsection-hero">
               <div class="subsection-hero-wrap">
@@ -29,6 +40,8 @@
                 </ol>
               </div>
             </div>
+
+
 
               <section class="type-details u-inline-block">
                   <div class="expandable expandable__padded expandable__no-bg" id="expandable__loan-term">

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -24,7 +24,7 @@
                     block__flush-top
                     block__flush-bottom
                     block__padded-bottom
-                    social-media_container">
+                    u-right-on-desktop">
           {{ social_media.render( {
                 'title':  'Check out this page from the @CFPB'
           } ) }}

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -121,11 +121,11 @@
               'title':  'Check out this page from the @CFPB'
         } ) }}
       </div>
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Other loan types</h3>
-      </header>
-
-      <div class="aside-chunk">
+      
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Other loan types</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__right jump-link__bg" href="../conventional-loans/">
@@ -139,12 +139,10 @@
           </li>
         </ul>
       </div>
-
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Related links</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Related links</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link icon-link__external-link jump-link__bg" href="http://www.benefits.va.gov/homeloans/" target="_blank">
@@ -164,11 +162,10 @@
         </ul>
       </div>
 
-      <header class="tabbed-header">
-        <h3 class="subhead tabbed-heading">Ask CFPB</h3>
-      </header>
-
-      <div class="aside-chunk">
+      <div class="block">
+        <h2 class="header-slug">
+          <span class="header-slug_inner">Ask CFPB</span>
+        </h2>
         <ul class="list list__links list__spaced">
           <li class="list_item">
             <a class="list_link jump-link jump-link__bg" href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options-subpage" %}
 
 {% block title %}Owning a Home: Loan Options{% endblock title %}
@@ -114,7 +115,13 @@
 
 
     <aside class="content_sidebar sans">
-        <header class="tabbed-header">
+      <div class="block
+                  block__flush-top">
+        {{ social_media.render( {
+              'title':  'Check out this page from the @CFPB'
+        } ) }}
+      </div>
+      <header class="tabbed-header">
         <h3 class="subhead tabbed-heading">Other loan types</h3>
       </header>
 

--- a/src/mortgage-closing/index.html
+++ b/src/mortgage-closing/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "mortgage-closing" %}
 {% block title %}Mortgage Closing{% endblock title %}
 {% block content %}
@@ -60,7 +61,12 @@
     </section>
     <!-- .content_main -->
     <aside class="content_sidebar">
-      <!-- STAY TUNED -->
+      <div class="block
+                  block__flush-top block__padded-top">
+        {{ social_media.render( {
+              'title':  'Check out this page from the @CFPB'
+        } ) }}
+      </div>
       <section class="block u-mt0">
         <header class="tabbed-header tabbed-pad-top">
           <h3 class="subhead tabbed-heading">Resources</h3>

--- a/src/mortgage-estimate/index.html
+++ b/src/mortgage-estimate/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "social-media.html" as social_media with context %}
 {% set active_page = "mortgage-estimate" %}
 {% block title %}Mortgage Estimate{% endblock title %}
 {% block content %}
@@ -70,7 +71,13 @@
     </section>
     <!-- .content_main -->
     <aside class="content_sidebar">
-      <!-- STAY TUNED -->
+      <div class="block
+                  block__flush-top
+                  block__padded-top">
+        {{ social_media.render( {
+              'title':  'Check out this page from the @CFPB'
+        } ) }}
+      </div>
       <section class="block u-mt0">
         <header class="tabbed-header tabbed-pad-top">
           <h3 class="subhead tabbed-heading">Resources</h3>

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -3,6 +3,7 @@
 {% set page_js = "process" %}
 
 {% import "nav-macro.html" as nav_macro with context %}
+{% import "social-media.html" as social_media %}
 {% import "_vars-process.html" as vars with context %}
 
 {% block title %}Owning a Home: Know the Process{% endblock title %}
@@ -69,9 +70,8 @@
 
       <div class="phase_data">
         <div class=" {% if active_phase.tools %} content-l {% endif %}">
-
-          {% if active_phase.tools %}
-            <div class="tools-col">
+          <div class="tools-col">
+            {% if active_phase.tools %}
               <section class="tools block block__bg block__padded-top">
                 <h3 class="h6 u-mb15">Tools for this Phase</h3>
                 {% for tool in active_phase.tools %}
@@ -85,8 +85,13 @@
                   </div>
                 {% endfor %}
               </section>
+              <div class="block">
+                {{ social_media.render( {
+                      'title':  'Check out this page from the @CFPB'
+                } ) }}
+              </div>
+              {% endif %}
             </div>
-          {% endif %}
 
           {% if steps|list|length %}
             <div class="{% if active_phase.tools %}steps-col{% endif %}">
@@ -192,8 +197,8 @@
               </section>
             </div>
           {% endif %}
+
         </div>
-      </div>
 
       <h4>Ready for more? Explore another phase in the mortgage process.</h4>
 

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -85,7 +85,7 @@
                   </div>
                 {% endfor %}
               </section>
-              <div class="block">
+              <div class="block block__bg u-no-bg">
                 {{ social_media.render( {
                       'title':  'Check out this page from the @CFPB'
                 } ) }}

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -44,3 +44,4 @@
 @import "module/helpers.less";
 @import "module/process.less";
 @import "module/print.less";
+@import "module/social-media.less";

--- a/src/static/css/module/helpers.less
+++ b/src/static/css/module/helpers.less
@@ -365,6 +365,10 @@ object {
     background-color: @block__bg;
 }
 
+.u-no-bg {
+   background-color: transparent;
+}
+
 .content-l_col {
     .respond-to-min(@tablet-min, {
         &.content-l_col-1-3 + &.content-l_col-2-3,
@@ -378,13 +382,18 @@ object {
 
 .content-l_col-1-4  {
   .respond-to-min(@tablet-min, {
-    .grid_column(1, 4);    
+    .grid_column(1, 4);
   });
 }
 
-.content-l_col-3-4  {    
+.content-l_col-3-4  {
   .respond-to-min(@tablet-min, {
-    .grid_column(3, 4);    
+    .grid_column(3, 4);
   });
 }
 
+.u-right-on-desktop {
+  .respond-to-min( 801px, {
+    text-align: right;
+  });
+}

--- a/src/static/css/module/loan-options.less
+++ b/src/static/css/module/loan-options.less
@@ -23,12 +23,6 @@ ul.unindent-ul{
   }
 }
 
-.respond-to-min( 801px, {
-  .content__loan-options .social-media_container {
-    text-align: right;
-  }
-});
-
 // Expandables
 
 .type-details {

--- a/src/static/css/module/loan-options.less
+++ b/src/static/css/module/loan-options.less
@@ -23,6 +23,11 @@ ul.unindent-ul{
   }
 }
 
+.respond-to-min( 801px, {
+  .content__loan-options .social-media_container {
+    text-align: right;
+  }
+});
 
 // Expandables
 

--- a/src/static/css/module/social-media.less
+++ b/src/static/css/module/social-media.less
@@ -1,0 +1,56 @@
+.m-social-media {
+    display: inline-block;
+
+    // This could be wrapped in the `m-social-media__share` modifier,
+    // but it's ok on its own too.
+    &_heading {
+        display: inline-block;
+        // 0.25em subtracted to compensate for inline spacing
+        padding-right: unit( @grid_gutter-width / 14px - 0.25em, em );
+        margin-bottom: 0;
+        vertical-align: middle;
+
+        &__es {
+            display: none;
+        }
+
+        [lang="es"] & {
+            display: none;
+        }
+
+        [lang="es"] &__es {
+            display: inline-block;
+        }
+    }
+
+    .list {
+        display: inline-block;
+        vertical-align: middle;
+        margin-bottom: 0;
+
+        .list_item {
+            // 0.25em subtracted to compensate for inline spacing
+            margin-right: unit( (@grid_gutter-width / 2) / @base-font-size-px - 0.25em, em );
+            margin-bottom: 0;
+        }
+
+        .list_item:last-child {
+            margin-right: 0;
+        }
+    }
+
+    &_icon {
+        color: @darkgray;
+        font-size: unit( @grid_gutter-width / @base-font-size-px, em );
+        line-height: 1;
+        .u-link__colors( @darkgray, @pacific-80 );
+        .u-link__no-border();
+    }
+
+    // Hide on print.
+    .respond-to-print( {
+        & {
+            display: none;
+        }
+    } );
+}


### PR DESCRIPTION
I've copied over the macro from cfgov-refresh and put it on the owning a
home subpages. There's just default share text for now.

## Review 

- @virginiacc 

## Testing

Click on the Twitter or Linked icons to test. Facebook icons won't work until this is on build because of URL restrictions.

URLs affected
- http://localhost:8000/owning-a-home/closing-disclosure/
- http://localhost:8000/owning-a-home/explore-rates/
- http://localhost:8000/owning-a-home/loan-estimate/
- http://localhost:8000/owning-a-home/loan-options/
- http://localhost:8000/owning-a-home/loan-options/FHA-loans/
- http://localhost:8000/owning-a-home/loan-options/conventional-loans/
- http://localhost:8000/owning-a-home/loan-options/special-loan-programs/
- http://localhost:8000/owning-a-home/mortgage-closing/
- http://localhost:8000/owning-a-home/mortgage-estimate/
- http://localhost:8000/owning-a-home/process/ <-- The links are under the key tools section