### PR TITLE
Add enter to the list verbotten keys

### DIFF
--- a/src/static/js/modules/explore-rates.js
+++ b/src/static/js/modules/explore-rates.js
@@ -67,6 +67,7 @@ var params = {
   'isJumbo':        false,
   'prevLoanType':   '',
   'prevLocation':   '',
+  'verbotenKeys':   [ 9, 37, 38, 39, 40, 13, 16 ], // tab, arrow keys, enter, shift
   'update':         function() {
     this.prevLoanType = this['loan-type'];
     this.prevLocation = this.location;
@@ -1184,22 +1185,17 @@ $( '.calc-loan-amt .recalc' ).on( 'keydown', function( event ) {
 // If not, replace the character with an empty string.
 $( '.calc-loan-amt .recalc' ).on( 'keyup', function( evt ) {
   // on keyup (not tab or arrows), immediately gray chart
-  if ( evt.which !== 9 && ( evt.which < 37 || evt.which > 40 ) ) {
+  if ( params.verbotenKeys.indexOf( evt.which ) === -1 ) {
     chart.startLoading();
   }
-  var inputVal = $( this ).val();
-  if ( !isNum( inputVal ) ) {
-    var updatedVal = inputVal.toString().replace( /[^0-9\\.,]+/g, '' );
-    $( this ).val( updatedVal );
-  }
+
 } );
 
 // delayed function for processing and updating
 $( '.calc-loan-amt, .credit-score' ).on( 'keyup', '.recalc', function( evt ) {
-  var verbotenKeys = [ 9, 37, 38, 39, 40 ];
   var element = this;
   // Don't recalculate on TAB or arrow keys.
-  if ( verbotenKeys.indexOf( evt.which ) === -1 ||
+  if ( params.verbotenKeys.indexOf( evt.which ) === -1 ||
        $( this ).hasClass( 'range' ) ) {
     delay( function() {
       processLoanAmount( element );


### PR DESCRIPTION
I've added the enter key as a verbotten key. Since there's two places
that track these keys, I've added it to the config to make it easier to
update.

I also found some code that wasn't doing much except messing with the
focus of cursor when editing numbers in the explore rates tool. 
The function on L1170 does the same as the deleted code.

## Review
- @virginiacc 

## Testing
Type in numbers in the fields. Hit enter and nothing should happen.

Edit the middle digit in one of the number-fields. (ex: Change 200,000 to 255,000.) The cursor should not reset to the end until you shift focus to another field.
