### PR TITLE
Added a brand header for Owning a Home pages

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -75,6 +75,7 @@
 
   <!-- PRIMARY CONTENT -->
   <div id="primary-content" tabindex="0">
+    {% include "brand-header.html" %}
     {% block content %}
       This will be replaced in templates that extend this, and override "content".
     {% endblock %}

--- a/src/_layouts/brand-header.html
+++ b/src/_layouts/brand-header.html
@@ -1,0 +1,16 @@
+<header aria-label="Owning a Home header" class="brand-header content">
+  <div class="content_wrapper">
+    <div class="brand-header__1-2-container">
+      <span class="cf-icon cf-icon-owning-home brand-header__icon" aria-hidden></span>
+      <span class="brand-header__headline">
+        This page is part of <a href="/owning-a-home/">Owning a Home</a>, the CFPB’s
+        set of tools and resources for homebuyers.
+      </span>
+    </div>
+    <div class="brand-header__1-2-container">
+      The CFPB is a U.S. government agency created in 2011.
+      We write and enforce rules to protect consumers,
+      and we provide free tools and resources to help you make financial decisions.
+    </div>
+  </div>
+</header>

--- a/src/_layouts/brand-header.html
+++ b/src/_layouts/brand-header.html
@@ -1,16 +1,19 @@
 <header aria-label="Owning a Home header" class="brand-header content">
   <div class="content_wrapper">
-    <div class="brand-header__1-2-container">
-      <span class="cf-icon cf-icon-owning-home brand-header__icon" aria-hidden></span>
-      <span class="brand-header__headline">
+
+    <div class="brand-header__1-2-container brand-header__1-2-container-with-icon">
+      <div class="brand-header__headline">
+        <span class="cf-icon cf-icon-owning-home brand-header__icon" aria-hidden></span>
         This page is part of <a href="/owning-a-home/">Owning a Home</a>, the CFPB’s
         set of tools and resources for homebuyers.
-      </span>
+      </div>
     </div>
+
     <div class="brand-header__1-2-container">
       The CFPB is a U.S. government agency created in 2011.
       We write and enforce rules to protect consumers,
       and we provide free tools and resources to help you make financial decisions.
     </div>
+
   </div>
 </header>

--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -24,6 +24,7 @@
 @import "../../vendor/bootstrap/tooltip.less";
 
 @import "module/breadcrumbs.less";
+@import "module/brand-header.less";
 @import "module/mixins.less";
 @import "module/typography.less";
 @import "module/layout.less";

--- a/src/static/css/module/brand-header.less
+++ b/src/static/css/module/brand-header.less
@@ -4,20 +4,6 @@
   padding-bottom: 30px;
   border-bottom: 1px solid @gray-50;
 
-  &__icon {
-    color: @green;
-    font-size: 2.5em;
-    text-align: center;
-    .grid_column(2);
-
-    + .brand-header__headline {
-      .grid_column(10);
-      .webfont-medium();
-      font-size: 18px;
-    }
-  }
-
-
   &__1-2-container {
     padding: 15px;
 
@@ -28,5 +14,22 @@
           border-left: 1px solid @gray-50;
         }
     });
+  }
+
+  &__1-2-container-with-icon {
+    .brand-header__icon {
+      color: @green;
+      font-size: 2.5em;
+      text-align: center;
+      position: absolute;
+      left: 0;
+    }
+
+    .brand-header__headline {
+      .webfont-medium();
+      font-size: 18px;
+      padding-left: 3em;
+      position: relative;
+    }
   }
 }

--- a/src/static/css/module/brand-header.less
+++ b/src/static/css/module/brand-header.less
@@ -1,0 +1,32 @@
+.brand-header {
+  background-color: @gray-10;
+  padding-top: 30px;
+  padding-bottom: 30px;
+  border-bottom: 1px solid @gray-50;
+
+  &__icon {
+    color: @green;
+    font-size: 2.5em;
+    text-align: center;
+    .grid_column(2);
+
+    + .brand-header__headline {
+      .grid_column(10);
+      .webfont-medium();
+      font-size: 18px;
+    }
+  }
+
+
+  &__1-2-container {
+    padding: 15px;
+
+    .respond-to-min( 799px, {
+        .grid_column(6);
+
+        &:last-child {
+          border-left: 1px solid @gray-50;
+        }
+    });
+  }
+}


### PR DESCRIPTION
Created an include for a brand header to be included on all Owning a
Home pages. Right now this will be only on non-wagtail pages, but any
advice that can make this portable to wagtail is appreciated.

## Review
- @virginiacc 

## Testing steps
- Run `grunt`
- Test the header on all non-wagtail "owning a home" pages.
- Test along multiple breakpoints

## Todo
- [ ] Add to CHANGELOG
