### PR TITLE
Reduce font sizes in brand header

### DIFF
--- a/src/_layouts/brand-header.html
+++ b/src/_layouts/brand-header.html
@@ -10,9 +10,11 @@
     </div>
 
     <div class="brand-header__1-2-container">
-      The CFPB is a U.S. government agency created in 2011.
-      We write and enforce rules to protect consumers,
-      and we provide free tools and resources to help you make financial decisions.
+      <div class="brand-header_text">
+        The CFPB is a U.S. government agency created in 2011.
+        We write and enforce rules to protect consumers,
+        and we provide free tools and resources to help you make financial decisions.
+      </div>
     </div>
 
   </div>

--- a/src/static/css/module/brand-header.less
+++ b/src/static/css/module/brand-header.less
@@ -16,6 +16,10 @@
     });
   }
 
+  &_text {
+    font-size: 14px;
+  }
+
   &__1-2-container-with-icon {
     .brand-header__icon {
       color: @green;
@@ -27,9 +31,10 @@
 
     .brand-header__headline {
       .webfont-medium();
-      font-size: 18px;
+      font-size: 16px;
       padding-left: 3em;
       position: relative;
     }
   }
+
 }


### PR DESCRIPTION
Make font sizes smaller in brand header so it's less dominant on the page

## Changes

- Reduce brand header headline font size to 16px & text font size to 14px


## Screenshots

<img width="1302" alt="screen shot 2016-11-15 at 9 13 37 am" src="https://cloud.githubusercontent.com/assets/778171/20316296/1b98db94-ab16-11e6-971a-489be1307ea9.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

