### PR TITLE
Add 2x2 layout for brand footer in 600-900px screen range

### DIFF
--- a/src/_layouts/brand-footer.html
+++ b/src/_layouts/brand-footer.html
@@ -17,24 +17,28 @@
                       - label: link label
                       - url: link url
 
-                      If there are more than three link objects, only the first
-                      three will be displayed.
+                      Macro will display max of three link sections. If there are 
+                      more than three link objects, only the first three will 
+                      be shown. If no links are passed in, only the email signup
+                      will be shown.
    ========================================================================== #}
 
-{% macro render(links) %}
+{% macro render(links=[]) %}
   <footer aria-label="Owning a Home footer" class="brand-footer content">
     <div class="content_wrapper">
-      <h3 class="brand-footer_headline">
+      <h3 class="brand-footer_headline u-mb0">
         <span class="cf-icon cf-icon-owning-home" aria-hidden></span>
         Check out other tools and resources from <a href="/owning-a-home">Owning a Home</a>
       </h3>
       {% for link in links %}
         {% if loop.index < 4 %}
-          {{render_link(link)}}
+          <div class="brand-footer_container brand-footer_container-{{loop.index}}">
+            {{render_link(link)}}
+          </div>
         {% endif %}
       {% endfor %}
-      <div class="brand-footer__1-4-container">
-        Email form goes here
+      <div class="brand-footer_container brand-footer_container-{{links|length + 1}}">
+        Email signup goes here
       </div>
     </div>
   </footer>
@@ -61,11 +65,11 @@
    ========================================================================== #}
 
 {% macro render_link(data) %}
-  <div class="brand-footer__1-4-container">
-    <a href="{{data.url}}" class="brand-footer_img-link"><img src="{{data.img}}"/></a>
-    <p>{{data.text|safe}}</p>
-    <a class="jump-link jump-link__block" href="{{data.url}}">
-      <span class="jump-link_text">{{data.label|safe}}</span>
-    </a>
+  <div class="brand-footer_img">
+    <a href="{{data.url}}"><img src="{{data.img}}"/></a>
   </div>
+  <p>{{data.text|safe}}</p>
+  <a class="jump-link jump-link__block" href="{{data.url}}">
+    <span class="jump-link_text">{{data.label|safe}}</span>
+  </a>
 {% endmacro %}

--- a/src/loan-options/index.html
+++ b/src/loan-options/index.html
@@ -365,7 +365,7 @@
                             <section class="col-4 sans">
                               <h4>Special programs</h4>
                               <ul class="list__unstyled list__spaced">
-                                <li class="list_item"><strong>VA:</strong> For veterans, servicemembers, or surviving spouses
+                                <li class="list_item"><strong>VA:</strong> For veterans, servicemembers, or surviving spouses</li>
                                 <li class="list_item"><strong>USDA:</strong> For low- to middle-income borrowers in rural areas</li>
                                 <li class="list_item"><strong>Local:</strong> For low- to middle-income borrowers, first-time homebuyers, or public service employees</li>
                               </ul>
@@ -378,7 +378,6 @@
 
                             <p><strong>Ask lenders if the loan they are offering you meets the government’s</strong> <a href="/askcfpb/1789/what-qualified-mortgage.html" target="_blank">Qualified Mortgage</a> standard. Qualified Mortgages are those that are safest for you, the borrower.</p>
 
-                            <p>
                           </div> <!-- /.note -->
 
                           <span class="expand-close">
@@ -390,12 +389,12 @@
 
 
             </section> <!-- /.type-details -->
+        </section>
+        {% include "ratings-form.html" %}
 
-      </section>
-
+      </div>
     </div>
-
-  <aside>
+    <aside>
     {% import "brand-footer.html" as brand_footer %}
     {% set footer_links = [
       {
@@ -419,11 +418,10 @@
     ]%}
     {{ brand_footer.render(footer_links) }}
   </aside>
-  <div class="content_wrapper content__2-1">
-    <div class="content_intro">
-      {% include "ratings-form.html" %}
-    </div>
-  </div>
+  
+  
 </main>
+
+
 
 {% endblock %}

--- a/src/static/css/module/brand-footer.less
+++ b/src/static/css/module/brand-footer.less
@@ -7,7 +7,7 @@
 	&_img {
 		text-align: center;
 
-		.respond-to-min( @bp-med-min, {
+		.respond-to-min( @bp-sm-min, {
 			text-align: left;
 		});
 
@@ -50,7 +50,7 @@
 			}
         });
 
-        .respond-to-min( @bp-med-min, {
+        .respond-to-min( 1000px, {
         	padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
         	.grid_column(3);
         });

--- a/src/static/css/module/brand-footer.less
+++ b/src/static/css/module/brand-footer.less
@@ -4,9 +4,15 @@
   	padding-bottom: 60px;
 	border-top: 1px solid @gray-50;
 
-	&_img-link {
-		&:after {
-			content: '' !important;
+	&_img {
+		text-align: center;
+
+		.respond-to-min( @bp-med-min, {
+			text-align: left;
+		});
+
+		a:after {
+			display: none !important;
 		}
 
 		img {
@@ -27,11 +33,25 @@
 		}
 	}
 
-	&__1-4-container {
-		padding-top: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
+	&_container {
+		padding-top: unit( (@grid_gutter-width * 1.5) / @base-font-size-px, em);
+
+		&-1 {
+			padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
+		}
+
 		.grid_column(12);
 
-        .respond-to-min( 600px, {
+        .respond-to-min( @bp-sm-min, {
+        	.grid_column(6);
+
+        	&-2 {
+				padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
+			}
+        });
+
+        .respond-to-min( @bp-med-min, {
+        	padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
         	.grid_column(3);
         });
 	}


### PR DESCRIPTION
Update brand footer layout in med screen range

## Additions

- `.grid_column(6)` layout in `@bp-sm` range & associated padding updates

## Changes
- fix positioning of footer on `/loan-options`
- fix some tags on `/loan-options`

## Testing

- Check out branch
- Run `grunt`
- Navigate to [/loan-options](http://localhost:8000/owning-a-home/loan-options/) and verify brand footer placement & layout across screen sizes

## Review

- @sonnakim 
- @huetingj 

## Screenshots

900px+:

<img width="883" alt="screen shot 2016-11-21 at 10 00 49 am" src="https://cloud.githubusercontent.com/assets/778171/20494525/37cd9c26-afd2-11e6-8ac0-1cd8ec978059.png">

600-899px:

<img width="841" alt="screen shot 2016-11-21 at 10 01 08 am" src="https://cloud.githubusercontent.com/assets/778171/20494543/43b4575a-afd2-11e6-8a6b-dfe9c4ffcd50.png">

< 600px:

<img width="579" alt="screen shot 2016-11-21 at 10 01 22 am" src="https://cloud.githubusercontent.com/assets/778171/20494563/5ab1622c-afd2-11e6-8dfb-747cbcfd84d1.png">


## Notes
- Should the icons be centered in the 600-900px range?
- Should the desktop breakpoint be greater than 900px? We might want to tweak it when the email signup is added.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

