### PR TITLE
Add custom social media content on /process pages

### DIFF
--- a/src/_layouts/social-media.html
+++ b/src/_layouts/social-media.html
@@ -40,7 +40,7 @@
 
    value.email_text         (Optional) body for email
 
-   value.email_signoff      (Optional) signoff for email
+   value.email_signature    (Optional) signature for email
 
    ========================================================================== #}
 
@@ -54,7 +54,7 @@
 {% set linkedin_text = value.linkedin_text | urlencode or blurb %}
 {% set email_title = value.email_title | urlencode or blurb %}
 {% set email_text = value.email_text | urlencode or blurb  %}
-{% set email_signoff = '%0A%0A' + value.email_signoff | urlencode if value.email_signoff else '' %}
+{% set email_signature = '%0A%0A' + value.email_signature | urlencode if value.email_signature else '' %}
 
 
 {% set parsed_url = request.url | urlencode %}
@@ -95,7 +95,7 @@
 
         {% set email_info = {
             'name': 'email',
-            'share_url': 'mailto:?subject=' ~ email_title ~ '&body=' ~ email_text ~ ' ' ~ parsed_url ~ email_signoff,
+            'share_url': 'mailto:?subject=' ~ email_title ~ '&body=' ~ email_text ~ ' ' ~ parsed_url ~ email_signature,
             'class': 'cf-icon-email-social-square'
         } %}
 

--- a/src/_layouts/social-media.html
+++ b/src/_layouts/social-media.html
@@ -40,6 +40,8 @@
 
    value.email_text         (Optional) body for email
 
+   value.email_signoff      (Optional) signoff for email
+
    ========================================================================== #}
 
 {% macro render( value={} ) %}
@@ -52,6 +54,8 @@
 {% set linkedin_text = value.linkedin_text | urlencode or blurb %}
 {% set email_title = value.email_title | urlencode or blurb %}
 {% set email_text = value.email_text | urlencode or blurb  %}
+{% set email_signoff = '%0A%0A' + value.email_signoff | urlencode if value.email_signoff else '' %}
+
 
 {% set parsed_url = request.url | urlencode %}
 {% set external_redirect_url = '/external-site/?ext_url=' %}
@@ -91,7 +95,7 @@
 
         {% set email_info = {
             'name': 'email',
-            'share_url': 'mailto:?subject=' ~ email_title ~ '&body=' ~ email_text ~ ' ' ~ parsed_url,
+            'share_url': 'mailto:?subject=' ~ email_title ~ '&body=' ~ email_text ~ ' ' ~ parsed_url ~ email_signoff,
             'class': 'cf-icon-email-social-square'
         } %}
 

--- a/src/_layouts/social-media.html
+++ b/src/_layouts/social-media.html
@@ -30,16 +30,32 @@
                             if other than English.
                             https://dev.twitter.com/web/tweet-button/parameters
 
+   value.twitter_text:      (Optional) content for tweet
+
+   value.linkedin_title     (Optional) title for LinkedIn post
+
+   value.linkedin_text      (Optional) text for LinkedIn post
+
+   value.email_title        (Optional) subject for email
+
+   value.email_text         (Optional) body for email
+
    ========================================================================== #}
 
 {% macro render( value={} ) %}
 
 {% set blurb = (value.blurb or (page.seo_title if page) or value.title or
                 'Look what I found on the CFPB’s site!') | urlencode %}
+
+{% set twitter_text = value.twitter_text | urlencode or blurb %}
+{% set linkedin_title = value.linkedin_title | urlencode or blurb %}
+{% set linkedin_text = value.linkedin_text | urlencode or blurb %}
+{% set email_title = value.email_title | urlencode or blurb %}
+{% set email_text = value.email_text or blurb  %}
+
 {% set parsed_url = request.url | urlencode %}
 {% set external_redirect_url = '/external-site/?ext_url=' %}
 {% set is_share_view = value.is_share_view | default( true ) %}
-
 <div class="m-social-media
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
     {% if is_share_view %}
@@ -62,20 +78,20 @@
         {% set twitter_info = {
             'name': 'Twitter',
             'homepage': 'https://twitter.com/cfpb',
-            'share_url': _share_twitter_url(parsed_url, blurb, value),
+            'share_url': _share_twitter_url(parsed_url, twitter_text, value),
             'class': 'cf-icon-twitter-square'
         } %}
 
         {% set linkedin_info = {
             'name': 'LinkedIn',
             'homepage': 'https://www.linkedin.com/company/consumer-financial-protection-bureau',
-            'share_url': 'https://www.linkedin.com/shareArticle?mini=true&url=' ~ parsed_url ~ '&title=' ~ blurb,
+            'share_url': 'https://www.linkedin.com/shareArticle?mini=true&url=' ~ parsed_url ~ '&title=' ~ linkedin_title ~ '&summary=' ~ linkedin_text,
             'class': 'cf-icon-linkedin-square'
         } %}
 
         {% set email_info = {
             'name': 'email',
-            'share_url': 'mailto:?subject=' ~ blurb ~ '&body=Check out this page from the CFPB - ' ~ parsed_url,
+            'share_url': 'mailto:?subject=' ~ email_title ~ '&body=' ~ email_text ~ ' ' ~ parsed_url,
             'class': 'cf-icon-email-social-square'
         } %}
 

--- a/src/_layouts/social-media.html
+++ b/src/_layouts/social-media.html
@@ -51,7 +51,7 @@
 {% set linkedin_title = value.linkedin_title | urlencode or blurb %}
 {% set linkedin_text = value.linkedin_text | urlencode or blurb %}
 {% set email_title = value.email_title | urlencode or blurb %}
-{% set email_text = value.email_text or blurb  %}
+{% set email_text = value.email_text | urlencode or blurb  %}
 
 {% set parsed_url = request.url | urlencode %}
 {% set external_redirect_url = '/external-site/?ext_url=' %}

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -103,10 +103,10 @@
                   </div>
                 {% endif %}
               </section>
-              <div class="block block__bg u-no-bg">
-                {{ social_media.render( {
-                      'title':  'Check out this page from the @CFPB'
-                } ) }}
+              <div class="block block__bg u-no-bg u-mt0">
+                {% set step_data = vars.process_steps[phase_index - 1] %}
+                {% set social_options = step_data.social or {} %}
+                {{ social_media.render( social_options  ) }}
               </div>
               {% endif %}
             </div>

--- a/src/process/_vars-process.html
+++ b/src/process/_vars-process.html
@@ -7,7 +7,8 @@
             "social": {
                 "twitter_text": "Check out the 8 steps to prepare to buy a home from @cfpb.",
                 "email_title": "8 steps to prepare to buy a home",
-                "email_text": "Check out the CFPB’s 8 steps to take when you are preparing to buy a home.  It covers everything from checking your credit to creating a budget to finding a network of people to advise you in your search, and much more. -- From the CFPB.",
+                "email_text": "Check out the CFPB’s 8 steps to take when you are preparing to buy a home.  It covers everything from checking your credit to creating a budget to finding a network of people to advise you in your search, and much more.",
+                "email_signoff": "-- From the CFPB",
                 "linkedin_title": "8 things to do when you prepare to buy a home from @CFPB",
                 "linkedin_text": "Here are 8 things you can do to prepare to buy a home. This helpful resource from the CFPB can help you understand the steps in the homebuying and mortgage process. Via @CFPB"
             }
@@ -19,7 +20,8 @@
             "social": {
                 "twitter_text": "Wondering what kind of mortgage is right for you? @CFPB can help!:",
                 "email_title": "Be a mortgage explorer: Learn your options",
-                "email_text": "Shopping for a mortgage can be complicated. Let the CFPB help you explore your home loan options. -- From the CFPB.",
+                "email_text": "Shopping for a mortgage can be complicated. Let the CFPB help you explore your home loan options.",
+                "email_signoff": "-- From the CFPB",
                 "linkedin_title": "Explore your home loan options",
                 "linkedin_text": "Get easy to follow directions from the CFPB that help you explore and understand your mortgage choices. Via @CFPB"
             }
@@ -31,7 +33,8 @@
             "social": {
                 "twitter_text": "To get the best deal on your mortgage, get more than one loan offer. @CFPB shows you how:",
                 "email_title": "Choose the mortgage loan offer that’s right for you.",
-                "email_text": "Understand your options, review and compare Loan Estimates, and choose the mortgage offer that is best for you. Get easy to understand definitions, interactive sample forms and more on the CFPB’s Owning a Home site. -- From the CFPB.",
+                "email_text": "Understand your options, review and compare Loan Estimates, and choose the mortgage offer that is best for you. Get easy to understand definitions, interactive sample forms and more on the CFPB’s Owning a Home site.",
+                "email_signoff": "-- From the CFPB",
                 "linkedin_title": "Compare mortgage offers and chose the right one for you",
                 "linkedin_text": "How do you choose the right loan offer? Learn what to do on the CFPB’s Owning a Home site. Via @CFPB"
             }
@@ -43,7 +46,8 @@
             "social": {
                 "twitter_text": "@CFPB helps you close with confidence on your mortgage:",
                 "email_title": "Get ready to close on your mortgage",
-                "email_text": "Read more on how to get ready to close on your mortgage loan with the CFPB’s “Owning a Home” suite of tools and resources. -- From the CFPB.",
+                "email_text": "Read more on how to get ready to close on your mortgage loan with the CFPB’s “Owning a Home” suite of tools and resources.",
+                "email_signoff": "-- From the CFPB",
                 "linkedin_title": "Close with confidence on your mortgage",
                 "linkedin_text": "The CFPB has helpful resources like a checklist, explainer, and guide to closing forms to help you through the closing process. Via @CFPB"
             }

--- a/src/process/_vars-process.html
+++ b/src/process/_vars-process.html
@@ -3,22 +3,53 @@
         {
             "url": "prepare",
             "title": "Prepare <br/>to shop",
-            "slug": "prepare-to-shop"
+            "slug": "prepare-to-shop",
+            "social": {
+                "twitter_text": "Check out the 8 steps to prepare to buy a home from @cfpb.",
+                "email_title": "8 steps to prepare to buy a home",
+                "email_text": "Check out the CFPB’s 8 steps to take when you are preparing to buy a home.  It covers everything from checking your credit to creating a budget to finding a network of people to advise you in your search, and much more. -- From the CFPB.",
+                "linkedin_title": "8 things to do when you prepare to buy a home from @CFPB",
+                "linkedin_text": "Here are 8 things you can do to prepare to buy a home. This helpful resource from the CFPB can help you understand the steps in the homebuying and mortgage process. Via @CFPB"
+            }
         },
         {
             "url": "explore",
             "title": "Explore <br/>loan choices",
-            "slug": "explore-loan-options"
+            "slug": "explore-loan-options",
+            "social": {
+                "twitter_text": "Wondering what kind of mortgage is right for you? @CFPB can help!:",
+                "email_title": "Be a mortgage explorer: Learn your options",
+                "email_text": "Shopping for a mortgage can be complicated. Let the CFPB help you explore your home loan options. -- From the CFPB.",
+                "linkedin_title": "Explore your home loan options",
+                "linkedin_text": "Get easy to follow directions from the CFPB that help you explore and understand your mortgage choices. Via @CFPB"
+            }
         },
         {
             "url": "compare",
             "title": "Compare <br/>loan offers",
-            "slug": "compare-and-negotiate-loan-packages"
+            "slug": "compare-and-negotiate-loan-packages",
+            "social": {
+                "twitter_text": "To get the best deal on your mortgage, get more than one loan offer. @CFPB shows you how:",
+                "email_title": "Choose the mortgage loan offer that’s right for you.",
+                "email_text": "Understand your options, review and compare Loan Estimates, and choose the mortgage offer that is best for you. Get easy to understand definitions, interactive sample forms and more on the CFPB’s Owning a Home site. -- From the CFPB.",
+                "linkedin_title": "Compare mortgage offers and chose the right one for you",
+                "linkedin_text": "How do you choose the right loan offer? Learn what to do on the CFPB’s Owning a Home site. Via @CFPB"
+            }
         },
         {
             "url": "close",
             "title": "Get ready <br/>to close",
-            "slug": "decide-and-close"
+            "slug": "decide-and-close",
+            "social": {
+                "twitter_text": "@CFPB helps you close with confidence on your mortgage:",
+                "email_title": "Get ready to close on your mortgage",
+                "email_text": "Read more on how to get ready to close on your mortgage loan with the CFPB’s “Owning a Home” suite of tools and resources. -- From the CFPB.",
+                "linkedin_title": "Close with confidence on your mortgage",
+                "linkedin_text": "The CFPB has helpful resources like a checklist, explainer, and guide to closing forms to help you through the closing process. Via @CFPB"
+            }
         }
     ]
 %}
+
+
+

--- a/src/process/_vars-process.html
+++ b/src/process/_vars-process.html
@@ -8,7 +8,7 @@
                 "twitter_text": "Check out the 8 steps to prepare to buy a home from @cfpb.",
                 "email_title": "8 steps to prepare to buy a home",
                 "email_text": "Check out the CFPB’s 8 steps to take when you are preparing to buy a home.  It covers everything from checking your credit to creating a budget to finding a network of people to advise you in your search, and much more.",
-                "email_signoff": "-- From the CFPB",
+                "email_signature": "-- From the CFPB",
                 "linkedin_title": "8 things to do when you prepare to buy a home from @CFPB",
                 "linkedin_text": "Here are 8 things you can do to prepare to buy a home. This helpful resource from the CFPB can help you understand the steps in the homebuying and mortgage process. Via @CFPB"
             }
@@ -21,7 +21,7 @@
                 "twitter_text": "Wondering what kind of mortgage is right for you? @CFPB can help!:",
                 "email_title": "Be a mortgage explorer: Learn your options",
                 "email_text": "Shopping for a mortgage can be complicated. Let the CFPB help you explore your home loan options.",
-                "email_signoff": "-- From the CFPB",
+                "email_signature": "-- From the CFPB",
                 "linkedin_title": "Explore your home loan options",
                 "linkedin_text": "Get easy to follow directions from the CFPB that help you explore and understand your mortgage choices. Via @CFPB"
             }
@@ -34,7 +34,7 @@
                 "twitter_text": "To get the best deal on your mortgage, get more than one loan offer. @CFPB shows you how:",
                 "email_title": "Choose the mortgage loan offer that’s right for you.",
                 "email_text": "Understand your options, review and compare Loan Estimates, and choose the mortgage offer that is best for you. Get easy to understand definitions, interactive sample forms and more on the CFPB’s Owning a Home site.",
-                "email_signoff": "-- From the CFPB",
+                "email_signature": "-- From the CFPB",
                 "linkedin_title": "Compare mortgage offers and chose the right one for you",
                 "linkedin_text": "How do you choose the right loan offer? Learn what to do on the CFPB’s Owning a Home site. Via @CFPB"
             }
@@ -47,7 +47,7 @@
                 "twitter_text": "@CFPB helps you close with confidence on your mortgage:",
                 "email_title": "Get ready to close on your mortgage",
                 "email_text": "Read more on how to get ready to close on your mortgage loan with the CFPB’s “Owning a Home” suite of tools and resources.",
-                "email_signoff": "-- From the CFPB",
+                "email_signature": "-- From the CFPB",
                 "linkedin_title": "Close with confidence on your mortgage",
                 "linkedin_text": "The CFPB has helpful resources like a checklist, explainer, and guide to closing forms to help you through the closing process. Via @CFPB"
             }


### PR DESCRIPTION
Add more content params to social media macro & set up customized content on /process pages

## Additions

- New params in `social-media.html` macro
- Per-page social media options in `_vars-process.html`

## Testing

- Check out branch and run grunt
- Navigate to process pages and verify that the linkedin, twitter, and email and icons generate customized posts/tweets/messages

## Review

- @sonnakim 

## Screenshots

Twitter:

<img width="679" alt="screen shot 2016-11-21 at 9 57 24 pm" src="https://cloud.githubusercontent.com/assets/778171/20512692/eaf9abd8-b035-11e6-96bd-8e197a02b0ce.png">

LinkedIn:

<img width="768" alt="screen shot 2016-11-21 at 9 57 33 pm" src="https://cloud.githubusercontent.com/assets/778171/20512697/f1f8f650-b035-11e6-977a-ae97296ef893.png">


Email:

<img width="761" alt="screen shot 2016-11-21 at 9 57 42 pm" src="https://cloud.githubusercontent.com/assets/778171/20512705/f6da53bc-b035-11e6-9cd8-ed12576c7a56.png">


## Todos

- @sonnakim, I copied over the tweet/post/email body text pretty directly, so let me know if any of the content should be arranged differently. Is the `--From the CFPB` in the email body intended as a signature?

- Update also needs to be made in cfgov-refresh for OAH landing page

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

