### PR TITLE
Update intro text on /explore-rates

### DIFF
--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -24,15 +24,16 @@
         <section class="page-intro content-l">
           <div class="content-l_col content-l_col-2-3">
             <h2 class="page-title">Explore interest rates<sup class="beta">BETA</sup></h2>
-            <p class="lead">Our data comes from actual lenders and is updated every day. Credit score, loan type, home price, and down payment amount all affect the interest rate you can get. Interest is only one of the many costs you will pay when getting a mortgage. While shopping, ask about <a href="/askcfpb/136/what-are-discount-points-or-points.html" target="_blank">points</a>, <a href="/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html" target="_blank">mortgage insurance</a>, and <a href="/askcfpb/139/what-are-closing-costs.html" target="_blank">closing costs</a>. Make a final decision only after comparing lenders’ <a href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">Loan Estimates</a> which include all the costs.</p>
-            <div class="block
-                        block__flush-top
-                        block__padded-top
-                        block__flush-bottom
-                        u-right-on-desktop">
-              {{ social_media.render( {
-                    'title':  'Check out this page from the @CFPB'
-              } ) }}
+            <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  Check back often -- the rates in the tool are updated daily.</p>
+            <div class="page-intro_cols">
+              <p class="page-intro_col-left u-mb30">
+                Keep in mind that the interest rate is important, but not the only cost of a mortgage.  Fees, <a href="http://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html">points</a>, <a href="http://www.consumerfinance.gov/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html">mortgage insurance</a>, and <a href="http://www.consumerfinance.gov/askcfpb/1845/what-fees-or-charges-are-paid-closing-and-who-pays-them.html">closing costs</a> all add up.  Compare <a href="http://www.consumerfinance.gov/askcfpb/1995/what-is-a-loan-estimate.html">Loan Estimates</a> to get the best deal.
+              </p>
+              <div class="page-intro_col-right u-right-on-desktop">
+                {{ social_media.render( {
+                      'title':  'Check out this page from the @CFPB'
+                } ) }}
+              </div>
             </div>
           </div>
           <div class="content-l_col content-l_col-1-3">

--- a/src/static/css/module/explore-rates.less
+++ b/src/static/css/module/explore-rates.less
@@ -8,6 +8,25 @@
     .page-intro {
       border-bottom: 1px solid @gray-10;
     }
+
+    .respond-to-min( 900px, {
+
+      .page-intro_cols {
+        display: table;
+
+        .page-intro_col-left,
+        .page-intro_col-right {
+          display: table-cell;
+
+        }
+
+        .page-intro_col-right {
+          padding-left: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+          white-space: nowrap;
+        }
+        
+      }
+    });
 }
 
 @media (max-width: 720px) {
@@ -673,3 +692,7 @@
 .related-links {
   margin-top: @grid_gutter-width;
 }
+
+
+
+


### PR DESCRIPTION
Update /explore-rates content


## Changes

- Text of /explore-rates intro

## Testing

- Check out branch and run grunt
- Navigate to http://localhost:8000/owning-a-home/explore-rates/
- Verify new intro text

## Review

- @sonnakim 
- @higs4281 

## Screenshots

Desktop:
<img width="1208" alt="screen shot 2016-11-29 at 7 39 02 am" src="https://cloud.githubusercontent.com/assets/778171/20716552/77af6816-b607-11e6-8e42-f4c2703f7e8f.png">

Mobile:
<img width="474" alt="screen shot 2016-11-29 at 7 39 10 am" src="https://cloud.githubusercontent.com/assets/778171/20716544/72041dbc-b607-11e6-8578-d3cd4fd1c186.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

