### PR TITLE
Form Explainer footer overlap fix

### DIFF
--- a/src/static/js/modules/form-explainer.js
+++ b/src/static/js/modules/form-explainer.js
@@ -92,10 +92,6 @@ formExplainer.resizeImage = function( els, $window, windowResize ) {
   }
 };
 
-formExplainer.test = function( el ) {
-  el.width( 200 );
-};
-
 formExplainer.setImageElementWidths = function( els ) {
   // When the sticky plugin is applied to the image, it adds position fixed,
   // and the image's width is no longer constrained to its parent.
@@ -138,10 +134,11 @@ formExplainer.fitAndStickToWindow = function( els, pageNum ) {
 
       if ( pageNum || els.$imageMapImage.closest( '.sticky-wrapper' ).length === 0 ) {
         // stick image to window
-        formExplainer.stickImage( els.$imageMapWrapper );
-      } else {
-        formExplainer.updateStickiness( els, $WINDOW.scrollTop() );
-      }
+        formExplainer.stickImage( els.$imageMapWrapper );        
+      } 
+
+      formExplainer.updateStickiness( els, $WINDOW.scrollTop() );
+      
       // hide pages except for first
       if ( pageNum > 1 ) {
         els.$page.hide();
@@ -504,6 +501,8 @@ $( document ).ready( function() {
       updateImagePositionAfterAnimation();
     }
   } );
+
+
 } );
 
 module.exports = formExplainer;


### PR DESCRIPTION
On page load, sometimes the form explainer sticky image overlaps the footer (per GHE 1244). 


## Changes

- Call `updateStickiness` in image onload handler on initial page load as well as when navigating between "pages" in the Form Explainer

## Removals
- unnecessary `formExplainer.test` test function 

## Testing

- Check out branch & run grunt
- Navigate to http://localhost:8000/owning-a-home/loan-estimate/, scroll footer in view, and reload page. Form explainer image should not overlap footer.
- Navigate to http://localhost:8000/owning-a-home in same tab and then use back button to return to /loan-estimate page. Form explainer image should not overlap footer.

## Review

- @sonnakim @mthibos @higs4281 

## Screenshots

What you should not see: 🙀 

![f05d220e-b624-11e6-826e-e86919785bc8](https://cloud.githubusercontent.com/assets/778171/20725965/8d991a7a-b628-11e6-8793-68d885b0d055.png)


## Notes

- I've only noticed the overlap on page load/refresh, so this fix should address that scenario. Let me know if you see it elsewhere!

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

