### PR TITLE
Small tweaks & content updates

### DIFF
--- a/src/_layouts/brand-footer.html
+++ b/src/_layouts/brand-footer.html
@@ -28,7 +28,7 @@
     <div class="content_wrapper">
       <h3 class="brand-footer_headline u-mb0">
         <span class="cf-icon cf-icon-owning-home" aria-hidden></span>
-        Check out other tools and resources from <a href="/owning-a-home" class="jump-link jump-link__block"><span class="jump-link_text">Owning a Home</span></a>
+        Check out other tools and resources from <a href="/owning-a-home" class="title-link">Owning a Home</a>
       </h3>
       {% for link in links %}
         {% if loop.index < 4 %}

--- a/src/_layouts/brand-footer.html
+++ b/src/_layouts/brand-footer.html
@@ -28,7 +28,7 @@
     <div class="content_wrapper">
       <h3 class="brand-footer_headline u-mb0">
         <span class="cf-icon cf-icon-owning-home" aria-hidden></span>
-        Check out other tools and resources from <a href="/owning-a-home">Owning a Home</a>
+        Check out other tools and resources from <a href="/owning-a-home" class="jump-link jump-link__block"><span class="jump-link_text">Owning a Home</span></a>
       </h3>
       {% for link in links %}
         {% if loop.index < 4 %}

--- a/src/_layouts/email-signup.html
+++ b/src/_layouts/email-signup.html
@@ -56,7 +56,7 @@
 		               required>
 		    </div>
 
-		    <p><a class="" href="/owning-a-home/privacy-act-statement/">Privacy Act statement</a> <br/></p>
+		    <p><a class="jump-link jump-link__block" href="/owning-a-home/privacy-act-statement/"><span class="jump-link_text">Privacy Act Statement</span></a> <br/></p>
 
 		    <input class="btn btn__full" type="submit" value="Sign up">
 		</div>

--- a/src/loan-options/FHA-loans/index.html
+++ b/src/loan-options/FHA-loans/index.html
@@ -2,7 +2,10 @@
 {% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options-subpage" %}
 
-{% block title %}Owning a Home: Loan Options{% endblock title %}
+
+{% block title %}FHA loans{% endblock title %}
+
+{% block metadescription %}FHA loans are loans from private lenders that are regulated by the Federal Housing Administration. Learn more from the Consumer Financial Protection Bureau.{% endblock metadescription %}
 
 {% block content %}
 

--- a/src/loan-options/special-loan-programs/index.html
+++ b/src/loan-options/special-loan-programs/index.html
@@ -2,7 +2,9 @@
 {% import "social-media.html" as social_media with context %}
 {% set active_page = "loan-options-subpage" %}
 
-{% block title %}Owning a Home: Loan Options{% endblock title %}
+{% block title %}Special loan programs{% endblock title %}
+
+{% block metadescription %}Mortgage shopping? Special loan programs can be more affordable than a conventional or FHA loan. Learn more from the Consumer Financial Protection Bureau.{% endblock metadescription %}
 
 {% block content %}
 

--- a/src/mortgage-estimate/index.html
+++ b/src/mortgage-estimate/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% import "social-media.html" as social_media with context %}
 {% set active_page = "mortgage-estimate" %}
-{% block title %}Questions about your the mortgage process?{% endblock title %}
+{% block title %}Questions about the mortgage process?{% endblock title %}
 {% block metadescription %}If you’ve received a Loan Estimate, you may be wondering what's next. The CFPB's tools and resources help you choose a mortgage that’s right for you.{% endblock metadescription %}
 {% block content %}
 <main class="content content__2-1 content__bleedbar form-resources" id="main" role="main">

--- a/src/static/css/module/brand-footer.less
+++ b/src/static/css/module/brand-footer.less
@@ -4,6 +4,10 @@
   	padding-bottom: 60px;
 	border-top: 1px solid @gray-50;
 
+	.title-link {
+  		border-bottom-width: 1px;
+	}
+
 	&_img {
 		text-align: center;
 
@@ -56,3 +60,4 @@
         });
 	}
 }
+

--- a/src/static/css/module/helpers.less
+++ b/src/static/css/module/helpers.less
@@ -397,3 +397,18 @@ object {
     text-align: right;
   });
 }
+
+a[href$='.PDF']:after,
+a[href$='.pdf']:after,
+a[href$='.doc']:after,
+a[href$='.docx']:after,
+a[href$='.xls']:after,
+a[href$='.xlsx']:after,
+a[href$='.csv']:after,
+a[href$='.zip']:after {
+    .cf-icon();
+    display: inline-block;
+    content: @cf-icon-download;
+    width: 1em;
+    text-align: right;
+}


### PR DESCRIPTION
Updates to footer and content

## Additions

- Title/meta description on `/loan-options/FHA-loans/` and `/loan-options/special-loan-programs/`

## Changes

- Capitalize `Statement` in email signup `Privacy Act Statement` link & make it a jump link so it has the same weight as other links in the footer
- Underline `Owning a Home` link in footer title
- Add pdf icon to pdf links in /closing-disclosure footer
- Fix typo in /mortgage-estimate title

## Testing

- Check out branch and run grunt
- Navigate to http://localhost:8000/owning-a-home/closing-disclosure/ and check footer fixes: 
  - `Privacy Act Statement` link is properly capitalized and styled like the other footer links
  - Two PDF links have download icons

## Review

- @sonnakim @higs4281  

## Screenshots
<img width="1230" alt="screen shot 2016-11-29 at 2 35 59 pm" src="https://cloud.githubusercontent.com/assets/778171/20732706/cdf4c012-b644-11e6-9ac8-53077b2f51d9.png">
<img width="593" alt="screen shot 2016-11-29 at 2 37 32 pm" src="https://cloud.githubusercontent.com/assets/778171/20732715/d6342c4a-b644-11e6-848b-a37b44a5adcb.png">
<img width="567" alt="screen shot 2016-11-29 at 2 39 03 pm" src="https://cloud.githubusercontent.com/assets/778171/20732717/d7e4f3e4-b644-11e6-8b7b-36254f0c2b55.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

