### PR TITLE
Add feedback module to form explainer pages

### DIFF
--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -51,10 +51,8 @@
         <div class="col-12">
           {% include "ratings-form.html" %}
         </div>
+        
     </div>
-
-    
-
   </div>
 
     {% import "brand-footer.html" as brand_footer %}

--- a/src/closing-disclosure/index.html
+++ b/src/closing-disclosure/index.html
@@ -47,8 +47,16 @@
         <div class="col-12">
           {{ form_explainer.render([ page_1, page_2, page_3, page_4, page_5 ]) }}
         </div>
+
+        <div class="col-12">
+          {% include "ratings-form.html" %}
+        </div>
     </div>
+
+    
+
   </div>
+
     {% import "brand-footer.html" as brand_footer %}
     {% set footer_links = [
       {

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -47,8 +47,13 @@
       <div class="col-12">
         {{ form_explainer.render([ page_1, page_2, page_3 ]) }}
       </div>
+
+      <div class="col-12">
+          {% include "ratings-form.html" %}
+        </div>
     </div><!-- /.form-explainer -->
   </div>
+
   {% import "brand-footer.html" as brand_footer %}
   {% set footer_links = [
     {

--- a/src/loan-estimate/index.html
+++ b/src/loan-estimate/index.html
@@ -49,8 +49,9 @@
       </div>
 
       <div class="col-12">
-          {% include "ratings-form.html" %}
-        </div>
+        {% include "ratings-form.html" %}
+      </div>
+      
     </div><!-- /.form-explainer -->
   </div>
 

--- a/src/static/css/module/form-explainer.less
+++ b/src/static/css/module/form-explainer.less
@@ -14,6 +14,10 @@
             display: none;
         });
     }
+
+    .rateq {
+        margin-top: 0px;
+    }
 }
 
 


### PR DESCRIPTION
Feedback form wasn't added to /closing-disclosure and /loan-estimate pages

## Additions

- Feedback form on /closing-disclosure and /loan-estimate pages
 

## Testing

- Check out branch and run grunt
- Navigate to http://localhost:8000/owning-a-home/loan-estimate/ and http://localhost:8000/owning-a-home/closing-disclosure and verify that feedback form appears on both

## Review

- @sonnakim 
- @higs4281 

## Screenshots

<img width="1310" alt="screen shot 2016-11-30 at 3 24 00 pm" src="https://cloud.githubusercontent.com/assets/778171/20775803/a52b7158-b711-11e6-90db-4e269883b50c.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

