### PR TITLE
Update Google Tag Manager snippets

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -44,6 +44,13 @@
     <script src="{{ url_for('static', filename='js/lte-ie8.js') }}"></script>
 <![endif]-->
 
+{# Google Tag Manager #}
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+
 {# Customized Modernizr build that includes html5shiv.
    Built via gulp-modernizer in the cfgov-refresh `scripts.js` task. #}
 <script src="{{ static('js/modernizr.min.js') }}"></script>
@@ -61,15 +68,10 @@
 </head>
 
 <body>
-    <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+    <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-    <!-- End Google Tag Manager -->
+    <!-- End Google Tag Manager (noscript) -->
 
 {% include "header.html" %}
 


### PR DESCRIPTION
The Analytics team requested we update our GTM snippets across all our sites. It now lives in the head but the `<noscript>` snippet remains in the body.