### PR TITLE
Modify `@grid_wrapper-width` to match Capital Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0] - 2017-01-03
 ### Changed
+- Modify `@grid_wrapper-width` to match Capital Framework
+
+## [2.0.0] - 2017-01-03
+### Changed
 - Increase loan limits to new 2017 figures
 
 ## [1.8.3] - 2016-12-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Changed
--
-
-## [2.0.0] - 2017-01-03
-### Changed
 - Modify `@grid_wrapper-width` to match Capital Framework
 
 ## [2.0.0] - 2017-01-03

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "owning-a-home",
   "description": "Owning A Home",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "http://github.com/cfpb/owning-a-home",
   "author": {
     "name": "Consumer Financial Protection Bureau",

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -76,7 +76,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% include "header.html" %}
 
   <!-- PRIMARY CONTENT -->
-  <div id="primary-content" tabindex="0">
+  <div class="oah-sheerlike" id="primary-content" tabindex="0">
     {% include "brand-header.html" %}
     {% block content %}
       This will be replaced in templates that extend this, and override "content".

--- a/src/static/css/cf-theme-overrides.less
+++ b/src/static/css/cf-theme-overrides.less
@@ -150,7 +150,7 @@
    ========================================================================== */
 
 @grid_box-sizing-polyfill-path: '/static/vendor/box-sizing-polyfill';
-@grid_wrapper-width:            1200px;
+@grid_wrapper-width:            1230px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;
 @grid_debug:                    false;

--- a/src/static/css/module/layout.less
+++ b/src/static/css/module/layout.less
@@ -1,7 +1,10 @@
 /* apply a natural box layout model to all elements */
-*, *:before, *:after {
-  -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
- }
+.oah-sheerlike {
+  box-sizing: border-box;
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
+}
 
 .wrap {
   max-width: 1100px;


### PR DESCRIPTION
Modify `@grid_wrapper-width` to match Capital Framework

## Changes

- Modified `@grid_wrapper-width`  to change it from `1200px` to `1230px`.

## Testing 

- Run `grunt`
- Visit `http://localhost:8000/owning-a-home/loan-options/` and observe the wider width for the body.


## Notes

- PR https://github.com/cfpb/cfgov-sheer-templates/pull/21 will need to be merged first  and a new shrinkwrap file generated for this repo.
 