### PR TITLE
Expose popup code for A/B tests

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -86,6 +86,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
 {% include "footer.html" %}
+{% include "email-popup.html" %}
 
 <!-- Common js -->
 <script src="{{ url_for('static', filename='js/main.js') }}?v7"></script>

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -229,9 +229,7 @@
 
       {{ nav_macro.render("bottom", active_phase.slug) }}
 
-      {% if step_data.display_email_popup %}
-        {% include "email-popup.html" %}
-      {% endif %}
+      
 
     </section> <!-- /.content_main -->
   </div>

--- a/src/static/js/modules/base.js
+++ b/src/static/js/modules/base.js
@@ -5,6 +5,9 @@ require( '../../../../node_modules/cfgov-sheer-templates/static/js/header.js' );
 require( '../../../../node_modules/cfgov-sheer-templates/static/js/footer.js' );
 require( './feedback.js' );
 var EmailSignup = require( './email-signup.js' );
+window.EmailPopup = require( './email-popup.js' );
+window.emailPopupHelpers = require( './email-signup-helpers.js' );
+
 var EMAIL_SIGNUP_BASE_CLASS = '.o-email-signup';
 
 $( EMAIL_SIGNUP_BASE_CLASS ).each( function( ind, item ) {

--- a/src/static/js/modules/email-popup.js
+++ b/src/static/js/modules/email-popup.js
@@ -14,6 +14,7 @@ var helpers = require( './email-signup-helpers.js' );
  * @returns {EmailSignup} An instance.
  */
 function EmailPopup( el ) {
+  el = el || '.email-popup';
   var _baseElement = $(el);
   var _closeElement = $(el).find('.close');
 
@@ -25,6 +26,7 @@ function EmailPopup( el ) {
   function showPopup() {
     _baseElement.fadeIn();
     helpers.recordEmailPopupView();
+    return this;
   }
 
   function init() {  

--- a/src/static/js/modules/email-signup-helpers.js
+++ b/src/static/js/modules/email-signup-helpers.js
@@ -25,9 +25,12 @@ function recordEmailPopupView() {
 
 function recordEmailPopupClosure() {
 	var count = POPUP_WAIT_PERIOD.length - 1;
-	var days = POPUP_WAIT_PERIOD[ count ];
-	localStorage.setItem( DISPLAY_COUNT_KEY, count );
-	localStorage.setItem( DISPLAY_DATE_KEY, getFutureDate( days ) );
+  var days = POPUP_WAIT_PERIOD[ count ];
+ 	localStorage.setItem( DISPLAY_COUNT_KEY, count );
+ 	var futureDate = getFutureDate( days );
+ 	if ( Number( localStorage.getItem(DISPLAY_DATE_KEY) ) < futureDate ) {
+   	localStorage.setItem( DISPLAY_DATE_KEY, getFutureDate( days ) );
+ 	}
 }
 
 function recordEmailRegistration() {

--- a/src/static/js/modules/process.js
+++ b/src/static/js/modules/process.js
@@ -51,7 +51,7 @@ $( document ).ready( function() {
     } );
   } );
 
-  if ( $( '.email-popup' ).length && emailHelpers.showEmailPopup() ) {
+  if ( !(/close/.test(window.location.href)) && emailHelpers.showEmailPopup() ) {
     var popup = new EmailPopup('.email-popup')
     popup.init();
     emailHelpers.showOnScroll(popup.el, {


### PR DESCRIPTION
Adds email popup template to base template and exposes code on window so it can be used in a/b tests

## Changes

- Add popup template to base template
- Expose EmailPopup on window

## Testing

- Check out branch and run grunt
- Clear local storage: 
  - `localStorage.setItem('oahPopupShowNext', '')`
- Initialize an email popup on any OAH page (except home page) from console: 
  - `var popup = new window.EmailPopup(); popup.init(); popup.showPopup();`
- Clear local storage and check that popup does not appear after scrolling down [process close page](http://localhost:8000/owning-a-home/process/close/)
- Check that popup does appear after scrolling 50% on [another journey page](http://localhost:8000/owning-a-home/process/prepare)

## Review

## Screenshots

## Todos

- 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

