### PR TITLE
Fix for global jQuery reference

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,7 +135,7 @@ module.exports = function( grunt ) {
           transform: [['browserify-shim', {global: true}], 'hbsfy', ['reactify', {harmony: true}]],
           plugin: [
             ['factor-bundle', {
-              
+
               o: [
                 'dist/static/js/base.js',
                 'dist/static/js/loan-options.js',
@@ -288,6 +288,12 @@ module.exports = function( grunt ) {
           },
           {
             expand: true,
+            cwd: 'node_modules/jquery/dist',
+            src: [ 'jquery.min.js' ],
+            dest: 'dist/static/js'
+          },
+          {
+            expand: true,
             cwd: 'src',
             src: [
               // move html & template files new template folders need to be added here
@@ -312,6 +318,12 @@ module.exports = function( grunt ) {
               "static/js/*"
             ],
             dest: 'dist/'
+          },
+          {
+            expand: true,
+            cwd: 'node_modules/jquery/dist',
+            src: [ 'jquery.min.js' ],
+            dest: 'dist/static/js'
           },
           {
             expand: true,

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -33,9 +33,11 @@
 <link rel="apple-touch-icon" size="144x144" href="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/apple-touch-icon-144x144-precomposed.png">
 
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}?v7">
- <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script>if (!window.jQuery) { document.write('<script src="{{ static('js/jquery.min.js') }}"><\/script>'); }
-    </script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script>if (!window.jQuery) {
+  document.write('<script src="{{ url_for('static', filename='js/jquery.min.js') }}"><\/script>');
+}
+</script>
 <!--[if IE 9]>
     <script src="{{ url_for('static', filename='js/ie9.js') }}"></script>
 <![endif]-->


### PR DESCRIPTION
Fix for global jQuery reference

## Testing

- Run `frontendbuild.sh`
- Verify that the script reference is correct when viewing source. 
 ( `http://localhost:8000/owning-a-home/explore-rates/`. ) 
- Verify that the CSS file is now available locally:  ( http://localhost:8000/static/owning-a-home/static/js/jquery.min.js )


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

