### PR TITLE
Hiding journey links on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update cfgov-sheer-templates dependency to 2.1.5 to support cfgov-refresh's
   update to Capital Framework 4.
+- Hiding journey links and adjusting process steps margin top.
 
 ## [2.0.2] - 2017-06-19
 ### Changed

--- a/src/process/_process-step.html
+++ b/src/process/_process-step.html
@@ -35,7 +35,7 @@
 
       {{ nav_macro.render("top", active_phase.slug) }}
 
-      <section class="overview content-l content-l__main u-mt45">
+      <section class="overview content-l content-l__main">
           <div class="content-l_col content-l_col-3-4">
               {% if active_phase.title %}
               <h1 class="phase_title">
@@ -229,7 +229,7 @@
 
       {{ nav_macro.render("bottom", active_phase.slug) }}
 
-      
+
 
     </section> <!-- /.content_main -->
   </div>

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -188,6 +188,10 @@ a.list_link {
   }
 
   .respond-to-max(@mobile-max, {
+    &__top {
+      display: none;
+    }
+
     .jump-link {
       border-top: 1px solid @gray-40;
       border-bottom: 1px solid @gray-40;

--- a/src/static/css/module/process.less
+++ b/src/static/css/module/process.less
@@ -187,9 +187,17 @@ a.list_link {
     }
   }
 
+  &__top + .overview {
+      margin-top: unit(45px / @base-font-size-px, em);
+  }
+
   .respond-to-max(@mobile-max, {
     &__top {
       display: none;
+
+      + .overview {
+          margin-top: unit(30px / @base-font-size-px, em);
+      }
     }
 
     .jump-link {


### PR DESCRIPTION
Hiding journey links on mobile

## Changes

- Modified `src/static/css/module/process.less` to remove journey links on mobile. GHE issue
- Run grunt
- Visit `http://localhost:8000/owning-a-home/process/prepare/` at a mobile width.
- Verify that the journey links on present( screenshots below depicts links ).


## screenshots

Before:
<img width="396" alt="screen shot 2017-07-05 at 5 44 13 pm" src="https://user-images.githubusercontent.com/1696212/27886818-ab35b190-61ab-11e7-8633-b3585accff5c.png">




After:
<img width="394" alt="screen shot 2017-07-05 at 5 44 43 pm" src="https://user-images.githubusercontent.com/1696212/27886819-ab39ea8a-61ab-11e7-8418-fb56d74ec307.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
