### PR TITLE
Override social sharing image

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -39,9 +39,9 @@
 <meta property="og:type" content="{% block og_type %}website{% endblock %}">
 <meta property="og:url" content="{{ request.url }}">
 <meta property="og:image"
-      content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_facebook.png') }}">
+      content="http://files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
 <meta property="twitter:image"
-      content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">
+      content="http://files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
 
 <!--  Optional -->
 <meta property="og:description" content="{{ self.metadescription() }}">

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -39,9 +39,9 @@
 <meta property="og:type" content="{% block og_type %}website{% endblock %}">
 <meta property="og:url" content="{{ request.url }}">
 <meta property="og:image"
-      content="http://files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
+      content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
 <meta property="twitter:image"
-      content="http://files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
+      content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-mortgages.original.png">
 
 <!--  Optional -->
 <meta property="og:description" content="{{ self.metadescription() }}">


### PR DESCRIPTION
Adds a category-specific social sharing image (i.e. mortgages).