### PR TITLE
Bump to latest cfgov-sheer-templates 2.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 ### Removed
+- Set header and footer on-demand CSS font paths to be absolute
+- Update header/footer to latest from cfgov-refresh.
+
+### Removed
 - IE7 CSS.
 
 ## [2.0.3] – 2017-07-14

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,24 +5,21 @@
   "requires": true,
   "dependencies": {
     "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
       "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
       "dev": true
     },
     "JSONStream": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
       "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
       "dev": true,
       "requires": {
         "jsonparse": "0.0.5",
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
@@ -33,34 +30,30 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
       "requires": {
-        "acorn": "2.7.0"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
       },
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
           "dev": true
         }
       }
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
       },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -72,7 +65,7 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
         "json-stable-stringify": "1.0.1"
       },
       "dependencies": {
@@ -82,7 +75,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         }
       }
@@ -101,12 +94,11 @@
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
       }
     },
     "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "amortize": {
@@ -115,14 +107,12 @@
       "integrity": "sha1-TcC6L28P4wjK6cMPU2ZU31F3t6A="
     },
     "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -133,25 +123,28 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
+    "ansistyles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+      "dev": true
+    },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
       }
     },
     "archy": {
@@ -167,21 +160,19 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -195,8 +186,7 @@
       "dev": true
     },
     "array-differ": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
       "integrity": "sha1-EuLJtwa+1HyLSDtX5IdHP7CGHzo=",
       "dev": true
     },
@@ -219,29 +209,25 @@
       "dev": true
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
       }
     },
     "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
@@ -252,40 +238,35 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
         "bn.js": "4.11.7",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
       "integrity": "sha1-raoExGu1jG3R8pTaPrJuYijrbkQ=",
       "dev": true,
       "requires": {
-        "util": "0.10.3"
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
       }
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
       "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
       "dev": true
     },
@@ -305,19 +286,25 @@
       }
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "async-some": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
+      "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
+      "dev": true,
+      "requires": {
+        "dezalgo": "1.0.3"
+      }
+    },
     "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -328,8 +315,7 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
@@ -352,8 +338,7 @@
       "dev": true
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
       "dev": true
     },
@@ -378,8 +363,7 @@
       }
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
       "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
       "dev": true
     },
@@ -398,9 +382,9 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "string_decoder": "0.10.31"
           }
         },
@@ -413,12 +397,11 @@
       }
     },
     "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "bn.js": {
@@ -428,63 +411,60 @@
       "dev": true
     },
     "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
       }
     },
     "bower": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.2.8.tgz",
+      "version": "https://registry.npmjs.org/bower/-/bower-1.2.8.tgz",
       "integrity": "sha1-9jwIBKJn1f+vL9P9SINn5z3OIC8=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
         "archy": "0.0.2",
         "bower-config": "0.5.2",
         "bower-endpoint-parser": "0.2.2",
         "bower-json": "0.4.0",
         "bower-logger": "0.2.2",
-        "bower-registry-client": "0.1.6",
+        "bower-registry-client": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.1.6.tgz",
         "cardinal": "0.4.4",
         "chalk": "0.2.1",
-        "chmodr": "0.1.2",
+        "chmodr": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.2.tgz",
         "decompress-zip": "0.0.8",
         "fstream": "0.1.31",
-        "fstream-ignore": "0.0.10",
-        "glob": "3.2.11",
+        "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.10.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
         "graceful-fs": "2.0.3",
-        "handlebars": "1.0.12",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
         "inquirer": "0.3.5",
-        "junk": "0.2.2",
+        "junk": "https://registry.npmjs.org/junk/-/junk-0.2.2.tgz",
         "lru-cache": "2.3.1",
-        "mkdirp": "0.3.5",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
         "mout": "0.7.1",
-        "nopt": "2.1.2",
-        "open": "0.0.5",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+        "open": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
         "osenv": "0.0.3",
-        "p-throttler": "0.0.1",
-        "promptly": "0.2.1",
+        "p-throttler": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
+        "promptly": "https://registry.npmjs.org/promptly/-/promptly-0.2.1.tgz",
         "q": "0.9.7",
-        "request": "2.27.0",
+        "request": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
         "request-progress": "0.3.1",
         "retry": "0.6.1",
-        "rimraf": "2.2.8",
-        "semver": "2.1.0",
-        "stringify-object": "0.1.8",
-        "sudo-block": "0.2.1",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
+        "stringify-object": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz",
+        "sudo-block": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.2.1.tgz",
         "tar": "0.1.20",
-        "tmp": "0.0.31",
-        "update-notifier": "0.1.10",
+        "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+        "update-notifier": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
         "which": "1.0.9"
       },
       "dependencies": {
@@ -495,14 +475,12 @@
           "dev": true
         },
         "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
           "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
           "dev": true
         },
         "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "dev": true
         },
@@ -528,7 +506,7 @@
           "dev": true,
           "requires": {
             "ansi-styles": "0.2.0",
-            "has-color": "0.1.7"
+            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
           }
         },
         "combined-stream": {
@@ -573,8 +551,7 @@
           }
         },
         "handlebars": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
+          "version": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
           "integrity": "sha1-GMbTRAw16RsZs/9YK5FRq0mF1Pw=",
           "dev": true,
           "requires": {
@@ -606,9 +583,9 @@
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "dev": true,
           "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
+            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+            "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
           }
         },
         "lru-cache": {
@@ -636,8 +613,7 @@
           "dev": true
         },
         "request": {
-          "version": "2.27.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "version": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
           "integrity": "sha1-37GiJN06Wput5DNwElA9cQ5Thmg=",
           "dev": true,
           "requires": {
@@ -647,7 +623,7 @@
             "form-data": "0.1.4",
             "hawk": "1.0.0",
             "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "mime": "1.2.11",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.3.0",
@@ -696,8 +672,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
           }
         }
       }
@@ -726,30 +702,27 @@
       "dev": true
     },
     "bower-registry-client": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.1.6.tgz",
+      "version": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.1.6.tgz",
       "integrity": "sha1-w650qY8k9Qo3O7yw70Q1WL4B1Lc=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "bower-config": "0.4.5",
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "bower-config": "https://registry.npmjs.org/bower-config/-/bower-config-0.4.5.tgz",
         "graceful-fs": "2.0.3",
         "lru-cache": "2.3.1",
-        "mkdirp": "0.3.5",
-        "request": "2.27.0",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
         "request-replay": "0.2.0",
-        "rimraf": "2.2.8"
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
       },
       "dependencies": {
         "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
           "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
           "dev": true
         },
         "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "dev": true
         },
@@ -763,14 +736,13 @@
           }
         },
         "bower-config": {
-          "version": "0.4.5",
-          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.4.5.tgz",
+          "version": "https://registry.npmjs.org/bower-config/-/bower-config-0.4.5.tgz",
           "integrity": "sha1-uqfO44L1OxO7YqSvrufAXyAUPBM=",
           "dev": true,
           "requires": {
             "graceful-fs": "2.0.3",
-            "mout": "0.6.0",
-            "optimist": "0.6.1",
+            "mout": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "osenv": "0.0.3"
           }
         },
@@ -847,9 +819,9 @@
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "dev": true,
           "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
+            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+            "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
           }
         },
         "lru-cache": {
@@ -859,8 +831,7 @@
           "dev": true
         },
         "mout": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz",
+          "version": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz",
           "integrity": "sha1-znq62BMNeWsJ1/tQm8xzsJvgJKY=",
           "dev": true
         },
@@ -877,13 +848,12 @@
           "dev": true
         },
         "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
           }
         },
         "qs": {
@@ -893,8 +863,7 @@
           "dev": true
         },
         "request": {
-          "version": "2.27.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "version": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
           "integrity": "sha1-37GiJN06Wput5DNwElA9cQ5Thmg=",
           "dev": true,
           "requires": {
@@ -904,7 +873,7 @@
             "form-data": "0.1.4",
             "hawk": "1.0.0",
             "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "mime": "1.2.11",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.3.0",
@@ -936,18 +905,17 @@
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
       }
     },
     "brorand": {
@@ -957,19 +925,17 @@
       "dev": true
     },
     "browser-pack": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
       "integrity": "sha1-XRxSf1bFgmd0EcTbKhKGSP9r8VA=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.6.4",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
         "combine-source-map": "0.3.0",
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+          "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "integrity": "sha1-SyyAY/j1Enh7I3X37p22kgj6Lcs=",
           "dev": true,
           "requires": {
@@ -994,8 +960,7 @@
       "dev": true
     },
     "browser-resolve": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
+      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
       "integrity": "sha1-Wa54IKgpVezTL1+3xGisIcRyOAY=",
       "dev": true,
       "requires": {
@@ -1003,56 +968,55 @@
       }
     },
     "browserify": {
-      "version": "3.44.2",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-3.44.2.tgz",
+      "version": "https://registry.npmjs.org/browserify/-/browserify-3.44.2.tgz",
       "integrity": "sha1-/6J4jQboBz/9c02Uw64nLKPdYwo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "assert": "1.1.2",
-        "browser-pack": "2.0.1",
-        "browser-resolve": "1.2.4",
-        "browserify-zlib": "0.1.4",
-        "buffer": "2.1.13",
-        "builtins": "0.0.7",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+        "assert": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+        "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "buffer": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz",
+        "builtins": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
         "commondir": "0.0.1",
-        "concat-stream": "1.4.10",
-        "console-browserify": "1.0.3",
-        "constants-browserify": "0.0.1",
-        "crypto-browserify": "1.0.9",
-        "deep-equal": "0.1.2",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz",
+        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+        "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
         "defined": "0.0.0",
-        "deps-sort": "0.1.2",
-        "derequire": "0.8.0",
-        "domain-browser": "1.1.7",
-        "duplexer": "0.1.1",
+        "deps-sort": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
+        "derequire": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
+        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
         "events": "1.0.2",
-        "glob": "3.2.11",
-        "http-browserify": "1.3.2",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "5.0.1",
-        "module-deps": "1.10.0",
-        "os-browserify": "0.1.2",
-        "parents": "0.0.3",
-        "path-browserify": "0.0.0",
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "http-browserify": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz",
+        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-5.0.1.tgz",
+        "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-1.10.0.tgz",
+        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
         "punycode": "1.2.4",
-        "querystring-es3": "0.2.0",
+        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
         "resolve": "0.6.3",
         "shallow-copy": "0.0.1",
         "shell-quote": "0.0.1",
-        "stream-browserify": "0.1.3",
-        "stream-combiner": "0.0.4",
-        "string_decoder": "0.0.1",
-        "subarg": "0.0.1",
-        "syntax-error": "1.1.6",
-        "through2": "0.4.2",
-        "timers-browserify": "1.0.3",
-        "tty-browserify": "0.0.0",
-        "umd": "2.0.0",
-        "url": "0.10.3",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
+        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+        "syntax-error": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+        "umd": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
       }
     },
     "browserify-aes": {
@@ -1065,7 +1029,7 @@
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.0",
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "browserify-cipher": {
@@ -1087,7 +1051,7 @@
       "requires": {
         "cipher-base": "1.0.4",
         "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "browserify-rsa": {
@@ -1101,16 +1065,15 @@
       }
     },
     "browserify-shim": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.4.1.tgz",
+      "version": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.4.1.tgz",
       "integrity": "sha1-QTkqGjKjA3O3hqQyFDWOTo3Yp1g=",
       "dev": true,
       "requires": {
-        "exposify": "0.1.5",
-        "mothership": "0.2.0",
-        "rename-function-calls": "0.1.1",
+        "exposify": "https://registry.npmjs.org/exposify/-/exposify-0.1.5.tgz",
+        "mothership": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
+        "rename-function-calls": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
         "resolve": "0.6.3",
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "browserify-sign": {
@@ -1124,27 +1087,25 @@
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
         "elliptic": "6.4.0",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "parse-asn1": "5.1.0"
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
       }
     },
     "buffer": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz",
+      "version": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz",
       "integrity": "sha1-yIg46/efMLi0pwd4hHC+qKYsI1U=",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "1.1.8"
+        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
       }
     },
     "buffer-xor": {
@@ -1159,15 +1120,19 @@
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "builtin-status-codes": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz",
+      "version": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz",
       "integrity": "sha1-MGN+4mKXisBxdOFtf4LwrQbgha0=",
       "dev": true
     },
     "builtins": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+      "version": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
       "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
       "dev": true
     },
@@ -1178,29 +1143,25 @@
       "dev": true
     },
     "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
       }
     },
     "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
@@ -1210,13 +1171,12 @@
       "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "0.4.4"
+        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+        "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz"
       }
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
@@ -1232,9 +1192,9 @@
       }
     },
     "cfgov-sheer-templates": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/cfgov-sheer-templates/-/cfgov-sheer-templates-2.1.8.tgz",
-      "integrity": "sha1-5/quj0gjMdGcxL/4Dpi/cw964KU="
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/cfgov-sheer-templates/-/cfgov-sheer-templates-2.1.9.tgz",
+      "integrity": "sha512-l2Db0uw+fnGzMoBCaZ3c2hIiMdOi9IMlIsY0yV20UNMs9BlhedNaeAMD8qtDGELmTU9qyQajk8YYq2fEcsmclw=="
     },
     "chai": {
       "version": "1.10.0",
@@ -1242,8 +1202,8 @@
       "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.0",
-        "deep-eql": "0.1.3"
+        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz"
       }
     },
     "chainsaw": {
@@ -1256,29 +1216,27 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
       }
     },
     "cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "version": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
       },
       "dependencies": {
         "domhandler": {
@@ -1287,7 +1245,7 @@
           "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
           }
         },
         "domutils": {
@@ -1296,42 +1254,38 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
           }
         },
         "htmlparser2": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
             "domhandler": "2.3.0",
             "domutils": "1.5.1",
-            "entities": "1.0.0",
-            "readable-stream": "1.1.14"
+            "entities": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
           },
           "dependencies": {
             "entities": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
               "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
               "dev": true
             }
           }
         },
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "chmodr": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.2.tgz",
       "integrity": "sha1-DdgEHJFQh1db7Dg7R4J7t1dqT9Y=",
       "dev": true
     },
@@ -1341,15 +1295,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
-        "async-each": "1.0.1",
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
         "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
       }
     },
     "cipher-base": {
@@ -1358,19 +1312,17 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
       "dev": true
     },
     "clean-css": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
+      "version": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
       "integrity": "sha1-K0sv1g8yRBCWIWriWiH6p0WA3IM=",
       "dev": true,
       "requires": {
@@ -1396,17 +1348,15 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
     },
@@ -1432,26 +1382,22 @@
       }
     },
     "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "coffee-script": {
-      "version": "1.3.3",
-      "resolved": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "version": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "version": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
     },
@@ -1463,16 +1409,15 @@
       "requires": {
         "convert-source-map": "0.3.5",
         "inline-source-map": "0.3.1",
-        "source-map": "0.1.43"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
       }
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
       }
     },
     "commander": {
@@ -1488,25 +1433,23 @@
       "dev": true
     },
     "commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "version": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
         "detective": "4.5.0",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
         "iconv-lite": "0.4.18",
-        "mkdirp": "0.5.1",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "private": "0.1.7",
         "q": "1.5.0",
         "recast": "0.11.23"
       },
       "dependencies": {
         "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         },
@@ -1517,25 +1460,23 @@
           "dev": true,
           "requires": {
             "acorn": "4.0.13",
-            "defined": "1.0.0"
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
           }
         },
         "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
@@ -1549,18 +1490,16 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           }
         },
         "q": {
@@ -1572,29 +1511,26 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
       }
     },
     "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
         "proto-list": "1.2.4"
       }
     },
@@ -1605,11 +1541,11 @@
       "dev": true,
       "requires": {
         "graceful-fs": "3.0.11",
-        "js-yaml": "3.6.1",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
         "mkdirp": "0.5.1",
-        "object-assign": "2.1.1",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
         "osenv": "0.1.4",
-        "user-home": "1.1.1",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
         "uuid": "2.0.3",
         "xdg-basedir": "1.0.1"
       },
@@ -1620,7 +1556,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "minimist": {
@@ -1644,8 +1580,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
           }
         },
         "uuid": {
@@ -1657,14 +1593,12 @@
       }
     },
     "console-browserify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz",
       "integrity": "sha1-04mNLDqTEC82QZf4h0tPkrUoao4=",
       "dev": true
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
       "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI=",
       "dev": true
     },
@@ -1681,14 +1615,12 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -1698,9 +1630,9 @@
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
       "dev": true,
       "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+        "lcov-parse": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+        "log-driver": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
         "minimist": "1.2.0",
         "request": "2.79.0"
       },
@@ -1730,9 +1662,9 @@
       "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "create-hmac": {
@@ -1743,59 +1675,53 @@
       "requires": {
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
       }
     },
     "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
       "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
       "dev": true
     },
     "css-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
       "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
       "dev": true
     },
     "css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
       "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "1.0.0",
-        "domutils": "1.4.3",
-        "nth-check": "1.0.1"
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+        "css-what": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+        "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
       },
       "dependencies": {
         "domutils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+          "version": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
           "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
           }
         }
       }
     },
     "css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
       "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
       "dev": true
     },
@@ -1806,8 +1732,7 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "version": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
@@ -1815,14 +1740,12 @@
       }
     },
     "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "version": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "dev": true
     },
     "d": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "dev": true,
       "requires": {
@@ -1842,17 +1765,15 @@
       }
     },
     "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -1870,17 +1791,15 @@
       "dev": true
     },
     "date-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
-        "time-zone": "0.1.0"
+        "time-zone": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz"
       }
     },
     "dateformat": {
-      "version": "1.0.2-1.2.3",
-      "resolved": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "version": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
@@ -1890,25 +1809,28 @@
       "integrity": "sha1-QkGn+/zoEalKF4Bp5eJQv4t1yIY="
     },
     "debowerify": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/debowerify/-/debowerify-0.7.1.tgz",
+      "version": "https://registry.npmjs.org/debowerify/-/debowerify-0.7.1.tgz",
       "integrity": "sha1-1gVSBEKnkS5tdlReDMLGuwNEREU=",
       "dev": true,
       "requires": {
-        "bower": "1.2.8",
-        "falafel": "0.3.1",
-        "through": "2.3.8"
+        "bower": "https://registry.npmjs.org/bower/-/bower-1.2.8.tgz",
+        "falafel": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
       "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
       "dev": true
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
+    },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -1923,7 +1845,7 @@
         "mkpath": "0.1.0",
         "nopt": "2.2.1",
         "q": "1.0.1",
-        "readable-stream": "1.1.14",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
         "touch": "0.0.2"
       },
       "dependencies": {
@@ -1933,7 +1855,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "nopt": {
@@ -1942,7 +1864,7 @@
           "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "q": {
@@ -1954,17 +1876,15 @@
       }
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
       }
     },
     "deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
       "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
       "dev": true
     },
@@ -1975,8 +1895,7 @@
       "dev": true
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -1987,18 +1906,17 @@
       "dev": true
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
         "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.2.8"
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
       },
       "dependencies": {
         "object-assign": {
@@ -2010,8 +1928,7 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -2022,19 +1939,17 @@
       "dev": true
     },
     "deps-sort": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
       "integrity": "sha1-2qL7YUoXyWN9gB4vVTOa43DzYRo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.6.4",
-        "minimist": "0.0.10",
-        "through": "2.3.8"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+          "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "integrity": "sha1-SyyAY/j1Enh7I3X37p22kgj6Lcs=",
           "dev": true,
           "requires": {
@@ -2053,32 +1968,29 @@
       }
     },
     "deps-topo-sort": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/deps-topo-sort/-/deps-topo-sort-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/deps-topo-sort/-/deps-topo-sort-0.2.1.tgz",
       "integrity": "sha1-S+ivB0dpcWSciwxIT9fUqHuLASo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "minimist": "0.0.5",
-        "through": "2.3.8"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
           "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
           "dev": true
         }
       }
     },
     "derequire": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
+      "version": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
       "integrity": "sha1-wffx2izt5Ere3gRzePA/RE6cTA0=",
       "dev": true,
       "requires": {
-        "esprima-fb": "3001.1.0-dev-harmony-fb",
-        "esrefactor": "0.1.0",
+        "esprima-fb": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+        "esrefactor": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
         "estraverse": "1.5.1"
       }
     },
@@ -2088,18 +2000,27 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "1.0.0"
       }
     },
     "detective": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
       "integrity": "sha1-d3gkRKt1K4jKG+Lp0KA5Xx2iXu0=",
       "dev": true,
       "requires": {
-        "escodegen": "1.1.0",
-        "esprima-fb": "3001.1.0-dev-harmony-fb"
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+        "esprima-fb": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+      }
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "diff": {
@@ -2120,56 +2041,49 @@
       }
     },
     "doctrine": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       },
       "dependencies": {
         "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
@@ -2179,7 +2093,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
       }
     },
     "domutils": {
@@ -2188,23 +2102,21 @@
       "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
       }
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       }
     },
     "ecc-jsbn": {
@@ -2227,14 +2139,13 @@
         "brorand": "1.1.0",
         "hash.js": "1.1.3",
         "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
@@ -2242,39 +2153,35 @@
       }
     },
     "end-of-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
       "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
       "dev": true,
       "requires": {
-        "once": "1.3.3"
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
       },
       "dependencies": {
         "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
           }
         }
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
     },
     "envify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+      "version": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
       "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
       "dev": true,
       "requires": {
-        "jstransform": "11.0.3",
-        "through": "2.3.8"
+        "jstransform": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "es5-ext": {
@@ -2284,8 +2191,7 @@
       "dev": true
     },
     "es5-shim": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
+      "version": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
       "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
       "dev": true
     },
@@ -2453,7 +2359,7 @@
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
         "es5-ext": "0.10.24",
         "es6-iterator": "0.1.3",
         "es6-symbol": "2.0.1"
@@ -2507,7 +2413,7 @@
           "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24",
             "es6-symbol": "2.0.1"
           }
@@ -2518,41 +2424,37 @@
           "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24"
           }
         }
       }
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
       "integrity": "sha1-xmOSP24gqtSNDA+knzHG1PSTYM8=",
       "dev": true,
       "requires": {
-        "esprima": "1.0.4",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
         "estraverse": "1.5.1",
         "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         }
       }
     },
     "escope": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz",
+      "version": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz",
       "integrity": "sha1-QYx6CvynIdr+ZZGT/Zhig+dGU48=",
       "dev": true,
       "requires": {
@@ -2560,44 +2462,43 @@
       }
     },
     "eslint": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "version": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.4.10",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
         "debug": "2.6.8",
-        "doctrine": "1.5.0",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
         "es6-map": "0.1.5",
-        "escope": "3.6.0",
+        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
         "espree": "3.4.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
         "glob": "7.1.2",
         "globals": "9.18.0",
         "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
         "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.6.1",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
         "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "optionator": "0.8.2",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.6.1",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
       },
       "dependencies": {
         "d": {
@@ -2641,26 +2542,23 @@
           }
         },
         "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
           "dev": true,
           "requires": {
             "es6-map": "0.1.5",
             "es6-weak-map": "2.0.2",
             "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
           }
         },
         "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
           "dev": true
         },
         "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
@@ -2670,42 +2568,40 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
+            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
             "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.1.0",
-            "figures": "1.7.0",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "lodash": "4.17.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+            "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+            "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           }
         },
         "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         },
         "lodash": {
@@ -2724,44 +2620,39 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           }
         },
         "mute-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
           "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
           "dev": true
         },
         "readline2": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "mute-stream": "0.0.5"
+            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
           }
         },
         "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
           }
         }
       }
@@ -2773,7 +2664,7 @@
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
-        "acorn-jsx": "3.0.1"
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
       },
       "dependencies": {
         "acorn": {
@@ -2785,8 +2676,7 @@
       }
     },
     "esprima-fb": {
-      "version": "3001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+      "version": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
       "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE=",
       "dev": true
     },
@@ -2815,25 +2705,22 @@
       }
     },
     "esrefactor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
       "integrity": "sha1-0UJ5WigjOauB6Ta1t6IbEb8ZexM=",
       "dev": true,
       "requires": {
-        "escope": "0.0.16",
-        "esprima": "1.0.4",
-        "estraverse": "0.0.4"
+        "escope": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "estraverse": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
           "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI=",
           "dev": true
         }
@@ -2882,65 +2769,58 @@
       }
     },
     "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
       }
     },
     "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
       }
     },
     "exposify": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/exposify/-/exposify-0.1.5.tgz",
       "integrity": "sha1-altW24WQcMLjKczUDlUZHdtX49Y=",
       "dev": true,
       "requires": {
-        "detective": "2.3.0",
-        "has-require": "1.1.0",
-        "through2": "0.4.2",
-        "transformify": "0.1.2"
+        "detective": "https://registry.npmjs.org/detective/-/detective-2.3.0.tgz",
+        "has-require": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+        "transformify": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz"
       },
       "dependencies": {
         "detective": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-2.3.0.tgz",
+          "version": "https://registry.npmjs.org/detective/-/detective-2.3.0.tgz",
           "integrity": "sha1-IefSyoDxr5KRuP/kygmxqdvbWuM=",
           "dev": true,
           "requires": {
-            "escodegen": "0.0.15",
+            "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz",
             "esprima": "1.0.2"
           }
         },
         "escodegen": {
-          "version": "0.0.15",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz",
+          "version": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz",
           "integrity": "sha1-/9qcsmtws098wZ8diHVlOa+1Q70=",
           "dev": true,
           "requires": {
             "esprima": "1.0.2",
-            "source-map": "0.1.43"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
           }
         },
         "esprima": {
@@ -2958,71 +2838,65 @@
       "dev": true
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
     },
     "factor-bundle": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/factor-bundle/-/factor-bundle-2.5.0.tgz",
+      "version": "https://registry.npmjs.org/factor-bundle/-/factor-bundle-2.5.0.tgz",
       "integrity": "sha1-jqiVfaOddYYoPMPuNTzZkRpF53k=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.8.4",
-        "browser-pack": "5.0.1",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+        "browser-pack": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
         "defined": "0.0.0",
-        "deps-topo-sort": "0.2.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
+        "deps-topo-sort": "https://registry.npmjs.org/deps-topo-sort/-/deps-topo-sort-0.2.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
         "labeled-stream-splicer": "1.0.2",
-        "minimist": "0.2.0",
-        "nub": "0.0.0",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+        "nub": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
         "outpipe": "1.1.1",
-        "reversepoint": "0.2.1",
-        "stream-combiner": "0.2.2",
-        "through2": "0.5.1",
-        "xtend": "4.0.1"
+        "reversepoint": "https://registry.npmjs.org/reversepoint/-/reversepoint-0.2.1.tgz",
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
           "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
           "dev": true,
           "requires": {
-            "jsonparse": "0.0.5",
-            "through": "2.3.8"
+            "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           },
           "dependencies": {
             "jsonparse": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+              "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
               "dev": true
             }
           }
         },
         "browser-pack": {
-          "version": "5.0.1",
-          "resolved": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "version": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
           "integrity": "sha1-QZdxmyDG4KqglFHFER5T77b7wY0=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
-            "combine-source-map": "0.6.1",
-            "defined": "1.0.0",
-            "through2": "1.1.1",
-            "umd": "3.0.1"
+            "combine-source-map": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+            "umd": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
           },
           "dependencies": {
             "JSONStream": {
@@ -3032,52 +2906,47 @@
               "dev": true,
               "requires": {
                 "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
               }
             },
             "defined": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
               "dev": true
             },
             "through2": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.1"
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
               }
             }
           }
         },
         "combine-source-map": {
-          "version": "0.6.1",
-          "resolved": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+          "version": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
           "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.5.0",
+            "convert-source-map": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "inline-source-map": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
             "lodash.memoize": "3.0.4",
-            "source-map": "0.4.4"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
           }
         },
         "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "version": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
         "inline-source-map": {
-          "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+          "version": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
           "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
           "dev": true,
           "requires": {
-            "source-map": "0.4.4"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
           }
         },
         "jsonparse": {
@@ -3087,83 +2956,73 @@
           "dev": true
         },
         "minimist": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
           "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
           "dev": true
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "stream-combiner": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+          "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
           "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1",
-            "through": "2.3.8"
+            "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
               }
             },
             "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
               "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
               "dev": true
             }
           }
         },
         "umd": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+          "version": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
           "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "falafel": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
       "integrity": "sha1-81RnSIFPfQlUPRny+z1gkPE2hT0=",
       "dev": true,
       "requires": {
@@ -3177,8 +3036,7 @@
       }
     },
     "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -3189,8 +3047,7 @@
       "dev": true
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
       "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
       "dev": true,
       "requires": {
@@ -3203,12 +3060,12 @@
           "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
           "dev": true,
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+            "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
             "promise": "7.3.1",
-            "setimmediate": "1.0.5",
+            "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "ua-parser-js": "0.7.13"
           }
         },
@@ -3221,31 +3078,28 @@
       }
     },
     "fbjs": {
-      "version": "0.1.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
+      "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
       "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
       "dev": true,
       "requires": {
-        "core-js": "1.2.7",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
         "promise": "7.3.1",
-        "whatwg-fetch": "0.9.0"
+        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
       },
       "dependencies": {
         "whatwg-fetch": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+          "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
           "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=",
           "dev": true
         }
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
         "object-assign": "4.1.1"
       },
       "dependencies": {
@@ -3258,12 +3112,11 @@
       }
     },
     "file-entry-cache": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
         "object-assign": "4.1.1"
       },
       "dependencies": {
@@ -3293,76 +3146,69 @@
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "minimatch": "0.3.0"
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
         "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
       }
     },
     "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
       "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
     },
     "findup-sync": {
-      "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "version": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2"
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
       },
       "dependencies": {
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         }
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         }
       }
     },
     "flux": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
       "dev": true,
       "requires": {
-        "fbemitter": "2.1.1",
-        "fbjs": "0.1.0-alpha.7",
-        "immutable": "3.8.1"
+        "fbemitter": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
       }
     },
     "for-in": {
@@ -3386,8 +3232,7 @@
       "integrity": "sha1-zF0NiuHUbMmlVcJoL5EJd4WZNd8="
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -3397,23 +3242,21 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
         "mime-types": "2.1.15"
       }
     },
     "format-usd": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/format-usd/-/format-usd-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/format-usd/-/format-usd-0.2.0.tgz",
       "integrity": "sha1-sqV9jWeMZb5ZtDjYP2jIOaBlb5s="
     },
     "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
       }
     },
     "fs-extra": {
@@ -3423,14 +3266,13 @@
       "dev": true,
       "requires": {
         "jsonfile": "1.1.1",
-        "mkdirp": "0.3.5",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
         "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -4453,9 +4295,9 @@
       "dev": true,
       "requires": {
         "graceful-fs": "3.0.11",
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
       },
       "dependencies": {
         "graceful-fs": {
@@ -4464,7 +4306,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "minimist": {
@@ -4485,19 +4327,17 @@
       }
     },
     "fstream-ignore": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.10.tgz",
+      "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.10.tgz",
       "integrity": "sha1-sQ+PUizFVBX4C0H306MubLolTow=",
       "dev": true,
       "requires": {
         "fstream": "0.1.31",
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
       }
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
@@ -4510,16 +4350,15 @@
       }
     },
     "gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "version": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "dev": true,
       "requires": {
-        "ansi": "0.3.1",
-        "has-unicode": "2.0.1",
-        "lodash.pad": "4.5.1",
-        "lodash.padend": "4.6.1",
-        "lodash.padstart": "4.6.1"
+        "ansi": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "lodash.pad": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+        "lodash.padend": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+        "lodash.padstart": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz"
       }
     },
     "gaze": {
@@ -4538,25 +4377,23 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
           }
         }
       }
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
       }
     },
     "getobject": {
@@ -4582,33 +4419,36 @@
         }
       }
     },
+    "github-url-from-username-repo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+      "dev": true
+    },
     "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "version": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
       }
     },
     "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
       }
     },
     "globals": {
@@ -4618,17 +4458,16 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
         "glob": "7.1.2",
         "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       },
       "dependencies": {
         "glob": {
@@ -4637,12 +4476,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "minimatch": {
@@ -4663,30 +4502,27 @@
       }
     },
     "globule": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
       "integrity": "sha1-JrZNEOHtyrYJjY/gC9K3PMoIqPs=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2",
-        "minimatch": "0.2.14"
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
       },
       "dependencies": {
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
           }
         }
       }
@@ -4721,125 +4557,112 @@
       "dev": true
     },
     "grunt": {
-      "version": "0.4.5",
-      "resolved": "http://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "version": "http://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
-        "dateformat": "1.0.2-1.2.3",
+        "async": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
+        "coffee-script": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+        "dateformat": "http://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
         "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
+        "exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+        "findup-sync": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
         "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+        "grunt-legacy-log": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+        "grunt-legacy-util": "http://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+        "hooker": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+        "iconv-lite": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+        "js-yaml": "http://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+        "lodash": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+        "nopt": "http://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+        "underscore.string": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
         "which": "1.0.9"
       },
       "dependencies": {
         "argparse": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
           },
           "dependencies": {
             "underscore.string": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+              "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
           }
         },
         "async": {
-          "version": "0.1.22",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "version": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
           "dev": true
         },
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
           }
         },
         "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "version": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
           "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
           "dev": true
         },
         "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "js-yaml": {
-          "version": "2.0.5",
-          "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "version": "http://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
           }
         },
         "lodash": {
-          "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "version": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         },
         "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
           }
         },
         "nopt": {
-          "version": "1.0.10",
-          "resolved": "http://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "version": "http://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         }
       }
@@ -4867,12 +4690,11 @@
       }
     },
     "grunt-banner": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.6.0.tgz",
       "integrity": "sha1-P4eQIdEj+linuloLb7a+QStYhaw=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
       }
     },
     "grunt-bower-task": {
@@ -4883,7 +4705,7 @@
       "requires": {
         "async": "0.1.22",
         "bower": "1.3.12",
-        "colors": "0.6.2",
+        "colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
         "lodash": "0.10.0",
         "rimraf": "2.0.3",
         "wrench": "1.4.4"
@@ -4940,7 +4762,7 @@
           "integrity": "sha1-N94O2zkEuvkK7hM4Sho3mgXuIUw=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9",
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
             "archy": "0.0.2",
             "bower-config": "0.5.2",
             "bower-endpoint-parser": "0.2.2",
@@ -4960,7 +4782,7 @@
             "insight": "0.4.3",
             "is-root": "1.0.0",
             "junk": "1.0.3",
-            "lockfile": "1.0.3",
+            "lockfile": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
             "lru-cache": "2.5.2",
             "mkdirp": "0.5.0",
             "mout": "0.9.1",
@@ -5045,14 +4867,14 @@
                 "form-data": "0.2.0",
                 "hawk": "1.1.1",
                 "http-signature": "0.10.1",
-                "json-stringify-safe": "5.0.1",
+                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                 "mime-types": "1.0.2",
                 "node-uuid": "1.4.8",
                 "oauth-sign": "0.5.0",
                 "qs": "2.3.3",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.4.3"
+                "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
               }
             },
             "rimraf": {
@@ -5069,7 +4891,7 @@
           "integrity": "sha1-fRCq+yCDe94EPEXkOgyMKM2q5F4=",
           "dev": true,
           "requires": {
-            "redeyed": "0.4.4"
+            "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz"
           }
         },
         "caseless": {
@@ -5085,7 +4907,7 @@
           "dev": true,
           "requires": {
             "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "has-ansi": "0.1.0",
             "strip-ansi": "0.3.0",
             "supports-color": "0.2.0"
@@ -5103,7 +4925,7 @@
           "integrity": "sha1-EtW90Vj/igsNtAEZiRPAPfBp9vU=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24",
             "memoizee": "0.3.10",
             "timers-ext": "0.1.2"
@@ -5205,7 +5027,7 @@
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "mkdirp": "0.5.0",
             "rimraf": "2.0.3"
           },
@@ -5225,7 +5047,7 @@
           "dev": true,
           "requires": {
             "fstream": "1.0.11",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4"
           }
         },
@@ -5236,9 +5058,9 @@
           "dev": true,
           "requires": {
             "graceful-fs": "3.0.11",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "1.0.0",
-            "once": "1.4.0"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
           },
           "dependencies": {
             "minimatch": {
@@ -5248,7 +5070,7 @@
               "dev": true,
               "requires": {
                 "lru-cache": "2.5.2",
-                "sigmund": "1.0.1"
+                "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
               }
             }
           }
@@ -5259,7 +5081,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "handlebars": {
@@ -5307,7 +5129,7 @@
           "requires": {
             "asn1": "0.1.11",
             "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
+            "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
           }
         },
         "inquirer": {
@@ -5318,12 +5140,12 @@
           "requires": {
             "chalk": "0.5.0",
             "cli-color": "0.3.3",
-            "figures": "1.7.0",
+            "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "lodash": "2.4.2",
             "mute-stream": "0.0.4",
             "readline2": "0.1.1",
             "rx": "2.5.3",
-            "through": "2.3.8"
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           },
           "dependencies": {
             "lodash": {
@@ -5358,7 +5180,7 @@
           "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24",
             "es6-weak-map": "0.1.4",
             "event-emitter": "0.3.5",
@@ -5433,7 +5255,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "oauth-sign": {
@@ -5499,14 +5321,14 @@
             "form-data": "0.1.4",
             "hawk": "1.1.1",
             "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "mime-types": "1.0.2",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.4.0",
             "qs": "1.2.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3"
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
           },
           "dependencies": {
             "async": {
@@ -5597,7 +5419,7 @@
             "array-filter": "0.0.1",
             "array-map": "0.0.0",
             "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         },
         "sntp": {
@@ -5652,15 +5474,14 @@
       }
     },
     "grunt-browserify": {
-      "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/grunt-browserify/-/grunt-browserify-4.0.1.tgz",
+      "version": "http://registry.npmjs.org/grunt-browserify/-/grunt-browserify-4.0.1.tgz",
       "integrity": "sha1-9c7ZAmlYqADy6ImOGk3x5SX/af8=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "browserify": "11.2.0",
-        "glob": "5.0.15",
-        "lodash": "3.10.1",
+        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+        "browserify": "http://registry.npmjs.org/browserify/-/browserify-11.2.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
         "resolve": "1.3.3",
         "watchify": "3.9.0"
       },
@@ -5672,159 +5493,148 @@
           "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           }
         },
         "assert": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "version": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
           "dev": true,
           "requires": {
-            "util": "0.10.3"
+            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
           }
         },
         "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
         "browser-pack": {
-          "version": "5.0.1",
-          "resolved": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "version": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
           "integrity": "sha1-QZdxmyDG4KqglFHFER5T77b7wY0=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
-            "combine-source-map": "0.6.1",
-            "defined": "1.0.0",
-            "through2": "1.1.1",
-            "umd": "3.0.1"
+            "combine-source-map": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+            "umd": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
           }
         },
         "browser-resolve": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+          "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
           "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
           "dev": true,
           "requires": {
-            "resolve": "1.1.7"
+            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
           },
           "dependencies": {
             "resolve": {
-              "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+              "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
               "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
               "dev": true
             }
           }
         },
         "browserify": {
-          "version": "11.2.0",
-          "resolved": "http://registry.npmjs.org/browserify/-/browserify-11.2.0.tgz",
+          "version": "http://registry.npmjs.org/browserify/-/browserify-11.2.0.tgz",
           "integrity": "sha1-oRu53SCdeVcrgT9+7q+Cil9cDk4=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
-            "assert": "1.3.0",
-            "browser-pack": "5.0.1",
-            "browser-resolve": "1.11.2",
-            "browserify-zlib": "0.1.4",
-            "buffer": "3.6.0",
-            "builtins": "0.0.7",
+            "assert": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+            "browser-pack": "http://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+            "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "buffer": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+            "builtins": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
             "commondir": "0.0.1",
-            "concat-stream": "1.4.10",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "0.0.1",
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+            "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
             "crypto-browserify": "3.11.1",
-            "defined": "1.0.0",
-            "deps-sort": "1.3.9",
-            "domain-browser": "1.1.7",
-            "duplexer2": "0.0.2",
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "deps-sort": "http://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+            "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "events": "1.0.2",
-            "glob": "4.5.3",
-            "has": "1.0.1",
-            "htmlescape": "1.1.1",
-            "https-browserify": "0.0.1",
-            "inherits": "2.0.3",
-            "insert-module-globals": "6.6.3",
-            "isarray": "0.0.1",
+            "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+            "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "htmlescape": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "insert-module-globals": "http://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "labeled-stream-splicer": "1.0.2",
-            "module-deps": "3.9.1",
-            "os-browserify": "0.1.2",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.0",
+            "module-deps": "http://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+            "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+            "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
             "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.0",
+            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
             "read-only-stream": "1.1.1",
             "readable-stream": "2.3.3",
             "resolve": "1.3.3",
             "shasum": "1.0.2",
             "shell-quote": "0.0.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "1.7.1",
-            "string_decoder": "0.10.31",
-            "subarg": "1.0.0",
-            "syntax-error": "1.1.6",
-            "through2": "1.1.1",
-            "timers-browserify": "1.0.3",
-            "tty-browserify": "0.0.0",
-            "url": "0.10.3",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4",
-            "xtend": "4.0.1"
+            "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "stream-http": "http://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "syntax-error": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+            "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+            "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "url": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           },
           "dependencies": {
             "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0"
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
               }
             }
           }
         },
         "buffer": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "version": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
           "requires": {
-            "base64-js": "0.0.8",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
           },
           "dependencies": {
             "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             }
           }
         },
         "combine-source-map": {
-          "version": "0.6.1",
-          "resolved": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+          "version": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
           "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.5.0",
+            "convert-source-map": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "inline-source-map": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
             "lodash.memoize": "3.0.4",
-            "source-map": "0.4.4"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
           }
         },
         "console-browserify": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "dev": true,
           "requires": {
@@ -5832,8 +5642,7 @@
           }
         },
         "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "version": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -5849,28 +5658,26 @@
             "create-hash": "1.1.3",
             "create-hmac": "1.1.6",
             "diffie-hellman": "5.0.2",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "pbkdf2": "3.0.12",
             "public-encrypt": "4.0.0",
             "randombytes": "2.0.5"
           }
         },
         "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         },
         "deps-sort": {
-          "version": "1.3.9",
-          "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+          "version": "http://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
             "shasum": "1.0.2",
-            "subarg": "1.0.0",
-            "through2": "1.1.1"
+            "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
           }
         },
         "detective": {
@@ -5880,45 +5687,42 @@
           "dev": true,
           "requires": {
             "acorn": "4.0.13",
-            "defined": "1.0.0"
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
           }
         },
         "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "inline-source-map": {
-          "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+          "version": "http://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
           "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
           "dev": true,
           "requires": {
-            "source-map": "0.4.4"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
           }
         },
         "insert-module-globals": {
-          "version": "6.6.3",
-          "resolved": "http://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+          "version": "http://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
           "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
-            "combine-source-map": "0.6.1",
-            "concat-stream": "1.4.10",
+            "combine-source-map": "http://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
             "is-buffer": "1.1.5",
-            "lexical-scope": "1.2.0",
+            "lexical-scope": "http://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
             "process": "0.11.10",
-            "through2": "1.1.1",
-            "xtend": "4.0.1"
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         },
         "jsonparse": {
@@ -5928,8 +5732,7 @@
           "dev": true
         },
         "lexical-scope": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+          "version": "http://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
           "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
           "dev": true,
           "requires": {
@@ -5937,14 +5740,12 @@
           }
         },
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
@@ -5952,59 +5753,54 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "module-deps": {
-          "version": "3.9.1",
-          "resolved": "http://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+          "version": "http://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.1",
-            "browser-resolve": "1.11.2",
-            "concat-stream": "1.4.10",
-            "defined": "1.0.0",
+            "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+            "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
             "detective": "4.5.0",
-            "duplexer2": "0.0.2",
-            "inherits": "2.0.3",
-            "parents": "1.0.1",
-            "readable-stream": "1.1.14",
+            "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "resolve": "1.3.3",
             "stream-combiner2": "1.0.2",
-            "subarg": "1.0.0",
-            "through2": "1.1.1",
-            "xtend": "4.0.1"
+            "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
               }
             }
           }
         },
         "parents": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
           "dev": true,
           "requires": {
-            "path-platform": "0.11.15"
+            "path-platform": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
           }
         },
         "path-platform": {
-          "version": "0.11.15",
-          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+          "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
           "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
           "dev": true
         },
@@ -6015,8 +5811,7 @@
           "dev": true
         },
         "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
@@ -6026,13 +5821,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           },
           "dependencies": {
             "isarray": {
@@ -6062,85 +5857,76 @@
           }
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "stream-browserify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "readable-stream": "2.3.3"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "subarg": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
           "dev": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
           }
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
               }
             }
           }
         },
         "umd": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+          "version": "http://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
           "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "grunt-combine-media-queries": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/grunt-combine-media-queries/-/grunt-combine-media-queries-1.0.20.tgz",
+      "version": "https://registry.npmjs.org/grunt-combine-media-queries/-/grunt-combine-media-queries-1.0.20.tgz",
       "integrity": "sha1-6XS3xg9CkmIljN5OD7NZAFXFqtM=",
       "dev": true,
       "requires": {
-        "css-parse": "1.7.0",
-        "publish": "0.5.0"
+        "css-parse": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+        "publish": "https://registry.npmjs.org/publish/-/publish-0.5.0.tgz"
       }
     },
     "grunt-concurrent": {
@@ -6183,12 +5969,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "minimatch": {
@@ -6212,64 +5998,57 @@
       }
     },
     "grunt-contrib-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
       "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "source-map": "0.5.6"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
       }
     },
     "grunt-contrib-copy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
         "file-sync-cmp": "0.1.1"
       }
     },
     "grunt-contrib-cssmin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.9.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.9.0.tgz",
       "integrity": "sha1-JyQfAWCohmZZ2rQNyMJ3bAHsfOI=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "clean-css": "2.1.8",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+        "clean-css": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
         "maxmin": "0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "version": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
           }
         },
         "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -6281,7 +6060,7 @@
       "integrity": "sha1-VmdHWsRRfzLKYjuaTYHWz0rtK1E=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
         "chalk": "0.5.1",
         "less": "1.7.5",
         "lodash": "2.4.2",
@@ -6307,7 +6086,7 @@
           "dev": true,
           "requires": {
             "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "has-ansi": "0.1.0",
             "strip-ansi": "0.3.0",
             "supports-color": "0.2.0"
@@ -6361,7 +6140,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "uglify-js": {
@@ -6370,17 +6149,16 @@
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
+            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
             "source-map": "0.1.34",
-            "uglify-to-browserify": "1.0.2",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "yargs": "3.5.4"
           }
         }
       }
     },
     "grunt-contrib-watch": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.4.4.tgz",
+      "version": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.4.4.tgz",
       "integrity": "sha1-Mg/HfFzTO3PlRGzZ7ZGWEhFqpjw=",
       "dev": true,
       "requires": {
@@ -6389,91 +6167,81 @@
       }
     },
     "grunt-eslint": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-18.1.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-18.1.0.tgz",
       "integrity": "sha1-6nAOIg7N35Yq6MMX8V6+22WpfIY=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "eslint": "2.13.1"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "eslint": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz"
       }
     },
     "grunt-legacy-log": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "grunt-legacy-log-utils": "0.1.1",
-        "hooker": "0.2.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+        "grunt-legacy-log-utils": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+        "hooker": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+        "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
       },
       "dependencies": {
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
       }
     },
     "grunt-legacy-log-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+        "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
       },
       "dependencies": {
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
       }
     },
     "grunt-legacy-util": {
-      "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "version": "http://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "exit": "0.1.2",
+        "async": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
+        "exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
         "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "0.9.2",
-        "underscore.string": "2.2.1",
+        "hooker": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+        "lodash": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+        "underscore.string": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
         "which": "1.0.9"
       },
       "dependencies": {
         "async": {
-          "version": "0.1.22",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "version": "http://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
           "dev": true
         },
         "lodash": {
-          "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "version": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
@@ -6497,24 +6265,21 @@
       }
     },
     "grunt-mocha-istanbul": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-mocha-istanbul/-/grunt-mocha-istanbul-2.4.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-mocha-istanbul/-/grunt-mocha-istanbul-2.4.0.tgz",
       "integrity": "sha1-T/JF4Q8lRAJs4V3d/aJcxlQu1pI=",
       "dev": true
     },
     "grunt-newer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/grunt-newer/-/grunt-newer-0.7.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-newer/-/grunt-newer-0.7.0.tgz",
       "integrity": "sha1-N22dm2TOXGSLa/ob2pj3vCGT5B4=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "rimraf": "2.2.6"
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
       },
       "dependencies": {
         "rimraf": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
           "dev": true
         }
@@ -6530,13 +6295,12 @@
       }
     },
     "grunt-string-replace": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-string-replace/-/grunt-string-replace-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/grunt-string-replace/-/grunt-string-replace-1.3.1.tgz",
       "integrity": "sha1-YzoDvHhIKg4OH5339kWBH8H7sWI=",
       "dev": true,
       "requires": {
         "async": "2.5.0",
-        "chalk": "1.1.3"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
       },
       "dependencies": {
         "async": {
@@ -6557,13 +6321,12 @@
       }
     },
     "grunt-usemin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-2.4.0.tgz",
+      "version": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-2.4.0.tgz",
       "integrity": "sha1-/ic+J5gpb6KR+oO+zB2fxAYV8pk=",
       "dev": true,
       "requires": {
         "debug": "1.0.5",
-        "lodash": "2.4.2"
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
       },
       "dependencies": {
         "debug": {
@@ -6576,8 +6339,7 @@
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         }
@@ -6589,7 +6351,7 @@
       "integrity": "sha1-rjNIO2/IIk6DQilt4Qjvk3V/duA=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.4.10",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
         "zlib-browserify": "0.0.3"
       }
     },
@@ -6603,29 +6365,26 @@
       }
     },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
         "commander": "2.11.0",
         "is-my-json-valid": "2.16.0",
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
       }
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -6633,26 +6392,22 @@
       }
     },
     "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-require": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz",
       "integrity": "sha1-QePou4YjRniT7bw5CaWJPeUsdvg=",
       "dev": true
     },
     "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
@@ -6662,7 +6417,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "hash.js": {
@@ -6671,20 +6426,19 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "1.0.0"
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
       }
     },
     "hbsfy": {
@@ -6692,7 +6446,7 @@
       "resolved": "https://registry.npmjs.org/hbsfy/-/hbsfy-1.3.2.tgz",
       "integrity": "sha1-IN8NGGZgD92zpigU+lFRT5rO11o=",
       "requires": {
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "hmac-drbg": {
@@ -6707,40 +6461,41 @@
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
     "htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
         "domhandler": "2.4.1",
         "domutils": "1.6.2",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
@@ -6750,13 +6505,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "string_decoder": {
@@ -6771,29 +6526,26 @@
       }
     },
     "http-browserify": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz",
       "integrity": "sha1-tWLDRHk0mmkNemWX30la76jGBPU=",
       "dev": true,
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
         "jsprim": "1.4.0",
         "sshpk": "1.13.1"
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
@@ -6804,8 +6556,7 @@
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
@@ -6816,42 +6567,36 @@
       "dev": true
     },
     "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "version": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
       "dev": true
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
@@ -6870,7 +6615,7 @@
           "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
@@ -6881,23 +6626,22 @@
       "integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
         "cli-color": "0.2.3",
         "lodash": "1.2.1",
         "mute-stream": "0.0.3"
       }
     },
     "insert-module-globals": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-5.0.1.tgz",
+      "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-5.0.1.tgz",
       "integrity": "sha1-7snA360wOA6O2jE6CUFl3C8jUNI=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "concat-stream": "1.4.10",
-        "lexical-scope": "1.1.1",
-        "process": "0.6.0",
-        "through": "2.3.8"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "insight": {
@@ -6912,7 +6656,7 @@
         "inquirer": "0.6.0",
         "lodash.debounce": "2.4.1",
         "object-assign": "1.0.0",
-        "os-name": "1.0.3",
+        "os-name": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
         "request": "2.79.0",
         "tough-cookie": "0.12.1"
       },
@@ -6942,7 +6686,7 @@
           "dev": true,
           "requires": {
             "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "has-ansi": "0.1.0",
             "strip-ansi": "0.3.0",
             "supports-color": "0.2.0"
@@ -6954,7 +6698,7 @@
           "integrity": "sha1-EtW90Vj/igsNtAEZiRPAPfBp9vU=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24",
             "memoizee": "0.3.10",
             "timers-ext": "0.1.2"
@@ -7012,7 +6756,7 @@
             "mute-stream": "0.0.4",
             "readline2": "0.1.1",
             "rx": "2.5.3",
-            "through": "2.3.8"
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           }
         },
         "lodash": {
@@ -7027,7 +6771,7 @@
           "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
+            "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "es5-ext": "0.10.24",
             "es6-weak-map": "0.1.4",
             "event-emitter": "0.3.5",
@@ -7087,12 +6831,11 @@
       "dev": true
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
       }
     },
     "is-buffer": {
@@ -7101,6 +6844,15 @@
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -7108,51 +6860,45 @@
       "dev": true
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
       }
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
       }
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
     "is-money-usd": {
@@ -7166,9 +6912,9 @@
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
+        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -7181,8 +6927,7 @@
       }
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -7190,54 +6935,47 @@
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
       }
     },
     "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
       }
     },
     "is-root": {
@@ -7247,20 +6985,17 @@
       "dev": true
     },
     "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
@@ -7271,25 +7006,22 @@
       "dev": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
-        "isarray": "1.0.0"
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
       }
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
@@ -7298,105 +7030,94 @@
       }
     },
     "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
+      "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
       "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.7.1",
-        "esprima": "2.5.0",
-        "fileset": "0.2.1",
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
+        "fileset": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
         "handlebars": "4.0.10",
-        "js-yaml": "3.6.1",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
         "supports-color": "3.2.3",
         "which": "1.2.14",
-        "wordwrap": "1.0.0"
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
       },
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "escodegen": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+          "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
           "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
           "dev": true,
           "requires": {
-            "esprima": "1.2.5",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.5.0",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
             "source-map": "0.2.0"
           },
           "dependencies": {
             "esprima": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "version": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
               "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
               "dev": true
             }
           }
         },
         "esprima": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
           "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
           "dev": true
         },
         "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "fast-levenshtein": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+          "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
           "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
           "dev": true
         },
         "fileset": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+          "version": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
           "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "minimatch": "2.0.10"
+            "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
           }
         },
         "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "handlebars": {
@@ -7405,8 +7126,8 @@
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "source-map": "0.4.4",
             "uglify-js": "2.8.29"
           },
@@ -7417,24 +7138,22 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
               }
             }
           }
         },
         "levn": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+          "version": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
           "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
           }
         },
         "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
@@ -7442,74 +7161,66 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
           },
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
               "dev": true
             }
           }
         },
         "optionator": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "version": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "1.0.7",
-            "levn": "0.2.5",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "0.0.3"
+            "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+            "levn": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
           },
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
               "dev": true
             }
           }
         },
         "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         },
@@ -7520,7 +7231,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "supports-color": {
@@ -7529,7 +7240,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
           }
         },
         "uglify-js": {
@@ -7540,7 +7251,7 @@
           "optional": true,
           "requires": {
             "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "yargs": "3.10.0"
           },
           "dependencies": {
@@ -7563,8 +7274,7 @@
           }
         },
         "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         },
@@ -7575,41 +7285,37 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
             "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
           }
         }
       }
     },
     "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "version": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
       "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
+        "commander": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
       },
       "dependencies": {
         "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
       }
     },
     "jit-grunt": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+      "version": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
       "integrity": "sha1-dcSz37gvtW5j18+W1Zce6OzvfjU=",
       "dev": true
     },
@@ -7633,18 +7339,16 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         }
@@ -7664,17 +7368,17 @@
       "dev": true,
       "requires": {
         "acorn": "0.12.0",
-        "acorn-globals": "1.0.9",
+        "acorn-globals": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
         "browser-request": "0.3.3",
         "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
+        "cssstyle": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
         "escodegen": "1.8.1",
-        "htmlparser2": "3.9.2",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
         "nwmatcher": "1.4.1",
-        "parse5": "1.5.1",
+        "parse5": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
         "request": "2.79.0",
-        "xml-name-validator": "2.0.1",
-        "xmlhttprequest": "1.8.0"
+        "xml-name-validator": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+        "xmlhttprequest": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
       },
       "dependencies": {
         "acorn": {
@@ -7692,7 +7396,7 @@
             "esprima": "2.7.3",
             "estraverse": "1.9.3",
             "esutils": "2.0.2",
-            "optionator": "0.8.2",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "source-map": "0.2.0"
           }
         },
@@ -7721,14 +7425,19 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
+    },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
@@ -7738,12 +7447,11 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
       }
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -7754,8 +7462,7 @@
       "dev": true
     },
     "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
@@ -7766,8 +7473,7 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
@@ -7778,9 +7484,9 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
       },
       "dependencies": {
         "assert-plus": {
@@ -7792,53 +7498,47 @@
       }
     },
     "jstransform": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "version": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
       "dev": true,
       "requires": {
         "base62": "1.2.0",
-        "commoner": "0.10.8",
-        "esprima-fb": "15001.1.0-dev-harmony-fb",
-        "object-assign": "2.1.1",
-        "source-map": "0.4.4"
+        "commoner": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+        "esprima-fb": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
       },
       "dependencies": {
         "esprima-fb": {
-          "version": "15001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "version": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
           "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
           "dev": true
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "jumbo-mortgage": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jumbo-mortgage/-/jumbo-mortgage-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/jumbo-mortgage/-/jumbo-mortgage-2.0.0.tgz",
       "integrity": "sha1-DTWGcX5xS4g4arvszpGM4SCOxXI=",
       "requires": {
-        "format-usd": "0.1.0"
+        "format-usd": "http://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz"
       },
       "dependencies": {
         "format-usd": {
-          "version": "0.1.0",
-          "resolved": "http://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz",
+          "version": "http://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz",
           "integrity": "sha1-b/VHWk3c62/F09L5P+3XDiZwrT4="
         }
       }
     },
     "junk": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-0.2.2.tgz",
+      "version": "https://registry.npmjs.org/junk/-/junk-0.2.2.tgz",
       "integrity": "sha1-1ZXrGZs3kwzs0fLFKCCEfoDkiuc=",
       "dev": true
     },
@@ -7857,8 +7557,8 @@
       "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
         "stream-splicer": "1.3.2"
       }
     },
@@ -7879,8 +7579,7 @@
       "optional": true
     },
     "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "version": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
@@ -7895,7 +7594,7 @@
         "mime": "1.2.11",
         "mkdirp": "0.5.1",
         "request": "2.40.0",
-        "source-map": "0.1.43"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
       },
       "dependencies": {
         "asn1": {
@@ -8005,7 +7704,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "hawk": {
@@ -8036,7 +7735,7 @@
           "requires": {
             "asn1": "0.1.11",
             "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
+            "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
           }
         },
         "mime-types": {
@@ -8096,14 +7795,14 @@
             "form-data": "0.1.4",
             "hawk": "1.1.1",
             "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "mime-types": "1.0.2",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.3.0",
             "qs": "1.0.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3"
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
           }
         },
         "sntp": {
@@ -8119,18 +7818,16 @@
       }
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
       }
     },
     "lexical-scope": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
       "integrity": "sha1-3rrBBnQ18TWdkPz9npS8su5Hsr8=",
       "dev": true,
       "requires": {
@@ -8138,71 +7835,64 @@
       }
     },
     "load-grunt-config": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
+      "version": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
       "integrity": "sha1-EPZrHwrVeLC+BH/8B+JRi7KYukE=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "glob": "3.2.11",
-        "jit-grunt": "0.8.0",
-        "js-yaml": "3.0.2",
-        "load-grunt-tasks": "0.3.0",
-        "lodash-node": "2.4.1"
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "jit-grunt": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+        "load-grunt-tasks": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+        "lodash-node": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
       },
       "dependencies": {
         "argparse": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
           }
         },
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "js-yaml": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
           "integrity": "sha1-mTeGX46Jel6JTnPCxc8uibMut3E=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
           }
         },
         "load-grunt-tasks": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+          "version": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
           "integrity": "sha1-1Sc+PYaJAZsx2c3ULhaDmdO0VgU=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.1.3",
-            "globule": "0.2.0"
+            "findup-sync": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+            "globule": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz"
           }
         },
         "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
           "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
           "dev": true
         }
       }
     },
     "load-grunt-tasks": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "integrity": "sha1-BDwErWnsyF4CqCJY/fJbenng22w=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.1.3",
-        "multimatch": "0.3.0"
+        "findup-sync": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz"
       }
     },
     "loan-calc": {
@@ -8211,8 +7901,7 @@
       "integrity": "sha1-2hNga9v/s9aETiyfBdw2qpYb1Lo="
     },
     "lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
       "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
       "dev": true
     },
@@ -8223,20 +7912,17 @@
       "dev": true
     },
     "lodash-node": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "version": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
       "integrity": "sha1-6oL3sQDHM9GkKvdoAeUGEF4qgOw=",
       "dev": true
     },
     "lodash._isnative": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
       "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
       "dev": true
     },
     "lodash._objecttypes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
       "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
       "dev": true
     },
@@ -8247,7 +7933,7 @@
       "dev": true,
       "requires": {
         "lodash.isfunction": "2.4.1",
-        "lodash.isobject": "2.4.1",
+        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
         "lodash.now": "2.4.1"
       }
     },
@@ -8258,12 +7944,11 @@
       "dev": true
     },
     "lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
       }
     },
     "lodash.memoize": {
@@ -8278,36 +7963,31 @@
       "integrity": "sha1-aHIVZQBSUYX6+WeFu3/n/hW1YsY=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1"
+        "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
       }
     },
     "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
       "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
       "dev": true
     },
     "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "dev": true
     },
     "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "version": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -8333,8 +8013,7 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
@@ -8383,7 +8062,7 @@
           "dev": true,
           "requires": {
             "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
+            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
             "strip-ansi": "0.1.1"
           }
         },
@@ -8412,24 +8091,23 @@
       }
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
         "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
         "kind-of": "3.2.2",
         "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
       }
     },
     "miller-rabin": {
@@ -8476,24 +8154,21 @@
       "dev": true
     },
     "minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+        "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
       }
     },
     "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
       "dev": true
     },
@@ -8504,40 +8179,36 @@
       "dev": true
     },
     "mocha": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+      "version": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "integrity": "sha1-FRdo3Sh161G8gpXpgAAm6fK7OY8=",
       "dev": true,
       "requires": {
-        "commander": "2.3.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
         "escape-string-regexp": "1.0.2",
         "glob": "3.2.3",
         "growl": "1.8.1",
-        "jade": "0.26.3",
-        "mkdirp": "0.5.1",
+        "jade": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "supports-color": "1.2.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
           "dev": true
         },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
           }
         },
         "diff": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
           "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
           "dev": true
         },
@@ -8554,38 +8225,34 @@
           "dev": true,
           "requires": {
             "graceful-fs": "2.0.3",
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
           }
         },
         "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
@@ -8598,8 +8265,7 @@
       }
     },
     "mocha-jsdom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz",
       "integrity": "sha1-4VdvvQYBzInTWKIToOVYXRt8egE=",
       "dev": true
     },
@@ -8642,7 +8308,7 @@
             "esprima": "2.7.3",
             "estraverse": "1.9.3",
             "esutils": "2.0.2",
-            "optionator": "0.8.2",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "source-map": "0.2.0"
           }
         },
@@ -8670,11 +8336,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "handlebars": {
@@ -8695,7 +8361,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
               }
             }
           }
@@ -8712,16 +8378,16 @@
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9",
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
             "async": "1.5.2",
             "escodegen": "1.8.1",
             "esprima": "2.7.3",
             "glob": "5.0.15",
             "handlebars": "4.0.10",
-            "js-yaml": "3.6.1",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
-            "once": "1.4.0",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "resolve": "1.1.7",
             "supports-color": "3.2.3",
             "which": "1.2.14",
@@ -8774,7 +8440,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "optimist": {
@@ -8783,7 +8449,7 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
             "wordwrap": "0.0.3"
           },
           "dependencies": {
@@ -8801,13 +8467,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "resolve": {
@@ -8826,7 +8492,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "stream-combiner2": {
@@ -8854,7 +8520,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
           }
         },
         "through2": {
@@ -8875,7 +8541,7 @@
           "optional": true,
           "requires": {
             "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "yargs": "3.10.0"
           },
           "dependencies": {
@@ -8916,45 +8582,42 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
             "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
           }
         }
       }
     },
     "module-deps": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-1.10.0.tgz",
+      "version": "https://registry.npmjs.org/module-deps/-/module-deps-1.10.0.tgz",
       "integrity": "sha1-V6nKydvQkkKOxSSfbPN/sknXfbY=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "browser-resolve": "1.2.4",
-        "concat-stream": "1.4.10",
-        "detective": "3.1.0",
-        "minimist": "0.0.10",
-        "parents": "0.0.2",
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "detective": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz",
         "resolve": "0.6.3",
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       },
       "dependencies": {
         "parents": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz",
+          "version": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz",
           "integrity": "sha1-ZxR4JuSX1AdZqvW6TJllm2A00wI=",
           "dev": true
         }
       }
     },
     "mothership": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
       "integrity": "sha1-k9SKL7w+UOKl/I7VhvW8RMZfmpk=",
       "dev": true,
       "requires": {
-        "find-parent-dir": "0.3.0"
+        "find-parent-dir": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
       }
     },
     "mout": {
@@ -8970,28 +8633,25 @@
       "dev": true
     },
     "multimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
       "integrity": "sha1-YD28P+MoHTOAlKHhuTqLXyvgONo=",
       "dev": true,
       "requires": {
-        "array-differ": "0.1.0",
-        "array-union": "0.1.0",
-        "minimatch": "0.3.0"
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
       },
       "dependencies": {
         "array-union": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+          "version": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
           "integrity": "sha1-7emAiDMGZeaZ4evwIny8YDTmJ9s=",
           "dev": true,
           "requires": {
-            "array-uniq": "0.1.1"
+            "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
           }
         },
         "array-uniq": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
+          "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
           "integrity": "sha1-WGHz7U5LthdVl6TgeOiqeOvpWMc=",
           "dev": true
         }
@@ -9011,8 +8671,7 @@
       "optional": true
     },
     "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
@@ -9034,17 +8693,16 @@
       "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
       }
     },
     "nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
       }
     },
     "noptify": {
@@ -9062,9 +8720,21 @@
           "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         }
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -9082,188 +8752,164 @@
       "integrity": "sha1-33w+1aJ3w/nUtdgZsFMR0QogCuY=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "ansi": "0.3.1",
-        "ansi-regex": "2.0.0",
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+        "ansi": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
-        "archy": "1.0.0",
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
         "async-some": "1.0.2",
-        "block-stream": "0.0.9",
-        "char-spinner": "1.0.1",
-        "chmodr": "1.0.2",
-        "chownr": "1.0.1",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.10",
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+        "char-spinner": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+        "chmodr": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+        "chownr": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+        "cmd-shim": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+        "columnify": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+        "config-chain": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
         "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "fs-vacuum": "1.2.9",
-        "fs-write-stream-atomic": "1.0.8",
-        "fstream": "1.0.10",
-        "fstream-npm": "1.1.1",
-        "github-url-from-git": "1.4.0",
+        "editor": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+        "fs-vacuum": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+        "fs-write-stream-atomic": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
+        "fstream": "1.0.11",
+        "fstream-npm": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+        "github-url-from-git": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
         "github-url-from-username-repo": "1.0.2",
-        "glob": "7.0.6",
-        "graceful-fs": "4.1.6",
-        "hosted-git-info": "2.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.5",
-        "inherits": "2.0.3",
-        "ini": "1.3.4",
-        "init-package-json": "1.9.4",
-        "lockfile": "1.0.1",
-        "lru-cache": "4.0.1",
-        "minimatch": "3.0.3",
-        "mkdirp": "0.5.1",
-        "node-gyp": "3.6.0",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "init-package-json": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+        "lockfile": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "node-gyp": "3.6.2",
         "nopt": "3.0.6",
-        "normalize-git-url": "3.0.2",
-        "normalize-package-data": "2.3.5",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "1.0.7",
-        "npm-package-arg": "4.1.0",
-        "npm-registry-client": "7.2.1",
-        "npm-user-validate": "0.1.5",
-        "npmlog": "2.0.4",
-        "once": "1.4.0",
-        "opener": "1.4.1",
-        "osenv": "0.1.3",
-        "path-is-inside": "1.0.1",
-        "read": "1.0.7",
+        "normalize-git-url": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+        "npm-cache-filename": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+        "npm-install-checks": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+        "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+        "npm-registry-client": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+        "npm-user-validate": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "opener": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.4",
-        "readable-stream": "2.1.5",
-        "realize-package-specifier": "3.0.1",
-        "request": "2.74.0",
-        "retry": "0.10.0",
-        "rimraf": "2.5.4",
-        "semver": "5.1.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.0",
-        "spdx-license-ids": "1.2.2",
-        "strip-ansi": "3.0.1",
+        "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+        "realize-package-specifier": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+        "retry": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+        "sha": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+        "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+        "sorted-object": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
         "tar": "2.2.1",
-        "text-table": "0.2.0",
-        "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "validate-npm-package-license": "3.0.1",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+        "umask": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
         "validate-npm-package-name": "2.2.2",
-        "which": "1.2.11",
-        "wrappy": "1.0.2",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
         "write-file-atomic": "1.1.4"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
           "dev": true
         },
         "ansi": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+          "version": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
           "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
           "dev": true
         },
         "ansi-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
           "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "dev": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
-        "async-some": {
-          "version": "1.0.2",
-          "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
-          "dev": true,
-          "requires": {
-            "dezalgo": "1.0.3"
-          }
-        },
         "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
           }
         },
         "char-spinner": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
           "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
           "dev": true
         },
         "chmodr": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
           "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
           "dev": true
         },
         "chownr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.6",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
           }
         },
         "columnify": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.0"
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wcwidth": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz"
           },
           "dependencies": {
             "wcwidth": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
               "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
               "dev": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
               },
               "dependencies": {
                 "defaults": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                   },
                   "dependencies": {
                     "clone": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
@@ -9274,296 +8920,245 @@
           }
         },
         "config-chain": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+          "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
           "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
           "dev": true,
           "requires": {
-            "ini": "1.3.4",
-            "proto-list": "1.2.4"
+            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "proto-list": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
           },
           "dependencies": {
             "proto-list": {
-              "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "version": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
               "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
           }
         },
-        "dezalgo": {
-          "version": "1.0.3",
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-          "dev": true,
-          "requires": {
-            "asap": "2.0.3",
-            "wrappy": "1.0.2"
-          },
-          "dependencies": {
-            "asap": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-              "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
-              "dev": true
-            }
-          }
-        },
         "editor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
           "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "fs-vacuum": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+          "version": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
           "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.6",
-            "path-is-inside": "1.0.1",
-            "rimraf": "2.5.4"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
           }
         },
         "fs-write-stream-atomic": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
+          "version": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
           "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.6",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.1.5"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "iferr": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
           },
           "dependencies": {
             "iferr": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "version": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "fstream": {
-          "version": "1.0.10",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.6",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.4"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
           }
         },
         "fstream-npm": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
           "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
           "dev": true,
           "requires": {
-            "fstream-ignore": "1.0.5",
-            "inherits": "2.0.3"
+            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
           },
           "dependencies": {
             "fstream-ignore": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
               "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "requires": {
-                "fstream": "1.0.10",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3"
+                "fstream": "1.0.11",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
               }
             }
           }
         },
         "github-url-from-git": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
           "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
           "dev": true
         },
-        "github-url-from-username-repo": {
-          "version": "1.0.2",
-          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
-          "dev": true
-        },
         "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.5",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.0"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
           },
           "dependencies": {
             "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
-          "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
           "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
           "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
           "dev": true
         },
         "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
-          "version": "1.9.4",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+          "version": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
           "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
           "dev": true,
           "requires": {
-            "glob": "6.0.4",
-            "npm-package-arg": "4.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.4",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1",
+            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+            "promzard": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+            "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
             "validate-npm-package-name": "2.2.2"
           },
           "dependencies": {
             "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
               },
               "dependencies": {
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
               }
             },
             "promzard": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "version": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
               }
             }
           }
         },
         "lockfile": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
           "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
           "dev": true
         },
         "lru-cache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
           "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.0.0"
+            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
           },
           "dependencies": {
             "pseudomap": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
               "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+              "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
               "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
               "dev": true
             }
           }
         },
         "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
           },
           "dependencies": {
             "brace-expansion": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
               "dev": true,
               "requires": {
-                "balanced-match": "0.4.2",
-                "concat-map": "0.0.1"
+                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
               },
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                   "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                   "dev": true
                 },
                 "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true
                 }
@@ -9572,41 +9167,39 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "node-gyp": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
-          "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dev": true,
           "requires": {
-            "fstream": "1.0.10",
-            "glob": "7.0.6",
-            "graceful-fs": "4.1.6",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
+            "fstream": "1.0.11",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "nopt": "3.0.6",
-            "npmlog": "2.0.4",
-            "osenv": "0.1.3",
-            "request": "2.74.0",
-            "rimraf": "2.5.4",
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+            "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+            "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
             "semver": "5.3.0",
             "tar": "2.2.1",
-            "which": "1.2.11"
+            "which": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
           },
           "dependencies": {
             "semver": {
@@ -9619,42 +9212,39 @@
         },
         "nopt": {
           "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "normalize-git-url": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+          "version": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
           "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+          "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
           },
           "dependencies": {
             "is-builtin-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
-                "builtin-modules": "1.1.0"
+                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
               },
               "dependencies": {
                 "builtin-modules": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                  "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                   "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
                   "dev": true
                 }
@@ -9663,224 +9253,199 @@
           }
         },
         "npm-cache-filename": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
           "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+          "version": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
           "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
           "dev": true,
           "requires": {
-            "npmlog": "2.0.4",
-            "semver": "5.1.0"
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
           }
         },
         "npm-package-arg": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+          "version": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
           "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "semver": "5.1.0"
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
           }
         },
         "npm-registry-client": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+          "version": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
           "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
           "dev": true,
           "requires": {
-            "concat-stream": "1.5.2",
-            "graceful-fs": "4.1.6",
-            "normalize-package-data": "2.3.5",
-            "npm-package-arg": "4.1.0",
-            "npmlog": "2.0.4",
-            "once": "1.4.0",
-            "request": "2.74.0",
-            "retry": "0.10.0",
-            "semver": "5.1.0",
-            "slide": "1.1.6"
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+            "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+            "retry": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+              "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
               "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
               },
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                   },
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
                   }
                 },
                 "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "retry": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+              "version": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
               "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
               "dev": true
             }
           }
         },
         "npm-user-validate": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+          "version": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
           "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
           "dev": true
         },
         "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+          "version": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
           "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.2",
-            "gauge": "1.2.7"
+            "ansi": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+            "gauge": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
           },
           "dependencies": {
             "are-we-there-yet": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
               "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
               "dev": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.1.5"
+                "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
               },
               "dependencies": {
                 "delegates": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
               }
             },
             "gauge": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+              "version": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
               "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
               "dev": true,
               "requires": {
-                "ansi": "0.3.1",
-                "has-unicode": "2.0.0",
-                "lodash.pad": "4.4.0",
-                "lodash.padend": "4.5.0",
-                "lodash.padstart": "4.5.0"
+                "ansi": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                "lodash.pad": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
+                "lodash.padend": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
+                "lodash.padstart": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz"
               },
               "dependencies": {
                 "has-unicode": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                  "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
                   "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
                   "dev": true
                 },
                 "lodash._baseslice": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                  "version": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
                   "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
                   "dev": true
                 },
                 "lodash._basetostring": {
-                  "version": "4.12.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+                  "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
                   "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
                   "dev": true
                 },
                 "lodash.pad": {
-                  "version": "4.4.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
+                  "version": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
                   "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
                   "dev": true,
                   "requires": {
-                    "lodash._baseslice": "4.0.0",
-                    "lodash._basetostring": "4.12.0",
-                    "lodash.tostring": "4.1.4"
+                    "lodash._baseslice": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                    "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+                    "lodash.tostring": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz"
                   }
                 },
                 "lodash.padend": {
-                  "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
+                  "version": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
                   "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
                   "dev": true,
                   "requires": {
-                    "lodash._baseslice": "4.0.0",
-                    "lodash._basetostring": "4.12.0",
-                    "lodash.tostring": "4.1.4"
+                    "lodash._baseslice": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                    "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+                    "lodash.tostring": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz"
                   }
                 },
                 "lodash.padstart": {
-                  "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
+                  "version": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
                   "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
                   "dev": true,
                   "requires": {
-                    "lodash._baseslice": "4.0.0",
-                    "lodash._basetostring": "4.12.0",
-                    "lodash.tostring": "4.1.4"
+                    "lodash._baseslice": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                    "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+                    "lodash.tostring": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz"
                   }
                 },
                 "lodash.tostring": {
-                  "version": "4.1.4",
-                  "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
+                  "version": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
                   "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
                   "dev": true
                 }
@@ -9889,150 +9454,94 @@
           }
         },
         "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
           }
         },
         "opener": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
+          "version": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
           "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
           "dev": true
         },
         "osenv": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+          "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
           "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.0",
-            "os-tmpdir": "1.0.1"
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
           },
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
               "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
               "dev": true
             },
             "os-tmpdir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+              "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
               "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
               "dev": true
             }
           }
         },
-        "path-is-inside": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "dev": true
-        },
         "read": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "version": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
-            "mute-stream": "0.0.5"
+            "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
           },
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+              "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
               "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
               "dev": true
             }
           }
         },
-        "read-installed": {
-          "version": "4.0.3",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-          "dev": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.6",
-            "read-package-json": "2.0.4",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.1.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.1"
-          },
-          "dependencies": {
-            "debuglog": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-              "dev": true
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-              "dev": true,
-              "requires": {
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.3",
-                "graceful-fs": "4.1.6",
-                "once": "1.4.0"
-              }
-            },
-            "util-extend": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
-              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
-              "dev": true
-            }
-          }
-        },
         "read-package-json": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+          "version": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
           "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
           "dev": true,
           "requires": {
-            "glob": "6.0.4",
-            "graceful-fs": "4.1.6",
-            "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.3.5"
+            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "json-parse-helpfulerror": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
           },
           "dependencies": {
             "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
               },
               "dependencies": {
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
               }
             },
             "json-parse-helpfulerror": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+              "version": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
               "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
               "requires": {
-                "jju": "1.3.0"
+                "jju": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
               },
               "dependencies": {
                 "jju": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                  "version": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
                   "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                   "dev": true
                 }
@@ -10041,159 +9550,141 @@
           }
         },
         "readable-stream": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           },
           "dependencies": {
             "buffer-shims": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
               "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
               "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             },
             "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
           }
         },
         "realize-package-specifier": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
           "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
           "dev": true,
           "requires": {
             "dezalgo": "1.0.3",
-            "npm-package-arg": "4.1.0"
+            "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz"
           }
         },
         "request": {
-          "version": "2.74.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.4.1",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.0-rc4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.11",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.1",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+            "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
           },
           "dependencies": {
             "aws-sign2": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true
             },
             "aws4": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+              "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
               "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
               "dev": true
             },
             "bl": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
               "dev": true,
               "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
               },
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                   },
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
@@ -10202,191 +9693,168 @@
               }
             },
             "caseless": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
               "dev": true
             },
             "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
               },
               "dependencies": {
                 "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
               }
             },
             "extend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
               "dev": true
             },
             "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
-              "version": "1.0.0-rc4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.11"
+                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                   "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                   "dev": true
                 }
               }
             },
             "har-validator": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.13.1",
-                "pinkie-promise": "2.0.1"
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
               },
               "dependencies": {
                 "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                   },
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                       }
                     },
                     "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
                   }
                 },
                 "commander": {
-                  "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                   "dev": true,
                   "requires": {
-                    "graceful-readlink": "1.0.1"
+                    "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                   },
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                   "dev": true,
                   "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
-                    "jsonpointer": "2.0.0",
-                    "xtend": "4.0.1"
+                    "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                    "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                    "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                   },
                   "dependencies": {
                     "generate-function": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
                       "dev": true
                     },
                     "generate-object-property": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                       "dev": true,
                       "requires": {
-                        "is-property": "1.0.2"
+                        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                       },
                       "dependencies": {
                         "is-property": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
                       "dev": true
                     },
                     "xtend": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                   "dev": true,
                   "requires": {
-                    "pinkie": "2.0.4"
+                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                   },
                   "dependencies": {
                     "pinkie": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                       "dev": true
                     }
@@ -10395,179 +9863,159 @@
               }
             },
             "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
               },
               "dependencies": {
                 "boom": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                   }
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1"
+                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                   }
                 },
                 "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                   "dev": true
                 },
                 "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                   }
                 }
               }
             },
             "http-signature": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.3.0",
-                "sshpk": "1.9.2"
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz"
               },
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                   "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                   "dev": true
                 },
                 "jsprim": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
                   "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
                   "dev": true,
                   "requires": {
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.2",
-                    "verror": "1.3.6"
+                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                   },
                   "dependencies": {
                     "extsprintf": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                       "dev": true
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                       "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
                       "dev": true
                     },
                     "verror": {
-                      "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                       "dev": true,
                       "requires": {
-                        "extsprintf": "1.0.2"
+                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                       }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "1.9.2",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
                   "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
                   "dev": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "dashdash": "1.14.0",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.6",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.0",
-                    "tweetnacl": "0.13.3"
+                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                   },
                   "dependencies": {
                     "asn1": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "assert-plus": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                       "dev": true
                     },
                     "dashdash": {
-                      "version": "1.14.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
                       "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                       }
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                       }
                     },
                     "getpass": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                       }
                     },
                     "jodid25519": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                       }
                     },
                     "jsbn": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                       "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "0.13.3",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
                       "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
                       "dev": true,
                       "optional": true
@@ -10577,150 +10025,129 @@
               }
             },
             "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
-              "version": "2.1.11",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
               "dev": true,
               "requires": {
-                "mime-db": "1.23.0"
+                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
                   "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
                   "dev": true
                 }
               }
             },
             "node-uuid": {
-              "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
               "dev": true
             },
             "oauth-sign": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
               "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "qs": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+              "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
               "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
               "dev": true
             },
             "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
               "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
               "dev": true
             },
             "tunnel-agent": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
               "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
               "dev": true
             }
           }
         },
         "retry": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+          "version": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
           "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
           "dev": true
         },
         "rimraf": {
-          "version": "2.5.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
           "requires": {
-            "glob": "7.0.6"
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
           }
         },
         "semver": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
           "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
           "dev": true
         },
         "sha": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.6",
-            "readable-stream": "2.0.2"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.1",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "process-nextick-args": "1.0.3",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.1"
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
               },
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
                   "dev": true
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                   "dev": true
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                  "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                   "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
                   "dev": true
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "dev": true
                 },
                 "util-deprecate": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
                   "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
                   "dev": true
                 }
@@ -10729,90 +10156,77 @@
           }
         },
         "slide": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
           "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
           "dev": true
         },
         "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
           "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
           }
         },
         "tar": {
           "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.10",
-            "inherits": "2.0.3"
+            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "fstream": "1.0.11",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
           }
         },
-        "text-table": {
-          "version": "0.2.0",
-          "dev": true
-        },
         "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "version": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
           "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.2"
+            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
           },
           "dependencies": {
             "spdx-correct": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
               }
             },
             "spdx-expression-parse": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
               "dev": true,
               "requires": {
-                "spdx-exceptions": "1.0.4",
-                "spdx-license-ids": "1.2.2"
+                "spdx-exceptions": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
               },
               "dependencies": {
                 "spdx-exceptions": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                  "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                   "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                   "dev": true
                 }
@@ -10820,52 +10234,25 @@
             }
           }
         },
-        "validate-npm-package-name": {
-          "version": "2.2.2",
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
-          "dev": true,
-          "requires": {
-            "builtins": "0.0.7"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "0.0.7",
-              "dev": true
-            }
-          }
-        },
         "which": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+          "version": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
           "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
           "dev": true,
           "requires": {
-            "isexe": "1.1.2"
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
           },
           "dependencies": {
             "isexe": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+              "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
               "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
               "dev": true
             }
           }
         },
         "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.1.4",
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.6",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
         }
       }
     },
@@ -10875,14 +10262,14 @@
       "integrity": "sha1-ZmBqSnNvHnegWaoHGnnJSreBhTo=",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "2.0.3",
-        "ini": "1.3.4",
+        "config-chain": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.3.3",
         "osenv": "0.1.4",
-        "semver": "2.1.0",
+        "semver": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
         "uid-number": "0.0.5"
       },
       "dependencies": {
@@ -10907,7 +10294,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "once": {
@@ -10916,7 +10303,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
           }
         },
         "osenv": {
@@ -10925,8 +10312,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
           }
         }
       }
@@ -10937,29 +10324,26 @@
       "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
       "dev": true,
       "requires": {
-        "ansi": "0.3.1",
+        "ansi": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
         "are-we-there-yet": "1.0.6",
-        "gauge": "1.2.7"
+        "gauge": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
       }
     },
     "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
       }
     },
     "nub": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
       "integrity": "sha1-s2m9Mr3eZq9ZYFw7BSC8IZ3MwE8=",
       "dev": true
     },
     "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -10970,31 +10354,27 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
       "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
       "dev": true
     },
     "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
     },
     "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
         "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
       }
     },
     "objectified": {
@@ -11014,23 +10394,20 @@
       }
     },
     "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
       "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
       "dev": true
     },
@@ -11045,56 +10422,50 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
       },
       "dependencies": {
         "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
       "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
       "dev": true,
       "requires": {
-        "osx-release": "1.1.0",
-        "win-release": "1.1.1"
+        "osx-release": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+        "win-release": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz"
       }
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -11105,17 +10476,15 @@
       "dev": true
     },
     "osx-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
       "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -11139,7 +10508,7 @@
             "array-filter": "0.0.1",
             "array-map": "0.0.0",
             "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         }
       }
@@ -11153,8 +10522,7 @@
       }
     },
     "p-throttler": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
       "integrity": "sha1-w0HjWJ7IQ4UqA15viObB6WFQAps=",
       "dev": true,
       "requires": {
@@ -11181,18 +10549,16 @@
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parents": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
       "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
       "dev": true,
       "requires": {
-        "path-platform": "0.0.1"
+        "path-platform": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
       }
     },
     "parse-asn1": {
@@ -11201,7 +10567,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
+        "asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
         "browserify-aes": "1.0.6",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.0",
@@ -11209,15 +10575,14 @@
       }
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
+        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
         "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
       }
     },
     "parse-ms": {
@@ -11227,26 +10592,22 @@
       "dev": true
     },
     "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "version": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
@@ -11257,8 +10618,7 @@
       "dev": true
     },
     "path-platform": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
       "integrity": "sha1-tVhdfDxGPYmqAGDYZhHPGv1hfio=",
       "dev": true
     },
@@ -11272,28 +10632,25 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
       }
     },
     "plur": {
@@ -11303,8 +10660,7 @@
       "dev": true
     },
     "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
@@ -11314,18 +10670,16 @@
       "integrity": "sha1-FhXGxcX54ZyiMAIsT5O1sZCedcg=",
       "dev": true,
       "requires": {
-        "source-map": "0.1.43"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
       }
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
@@ -11341,7 +10695,7 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
         "parse-ms": "1.0.1",
         "plur": "1.0.0"
       }
@@ -11353,20 +10707,17 @@
       "dev": true
     },
     "process": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
       "integrity": "sha1-fdm+gP+q7dTLYo8YJ/HLq23AkY8=",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
@@ -11380,8 +10731,7 @@
       }
     },
     "promptly": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/promptly/-/promptly-0.2.1.tgz",
       "integrity": "sha1-ZETnyk29mJnn7rXsOSKCfr3CKzs=",
       "dev": true,
       "requires": {
@@ -11408,29 +10758,26 @@
       }
     },
     "publish": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/publish/-/publish-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/publish/-/publish-0.5.0.tgz",
       "integrity": "sha1-vn73r3inogUb0gDW0XeKC+K0lh8=",
       "dev": true,
       "requires": {
-        "nopt": "3.0.6",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
         "npm": "2.15.12",
         "npmlog": "1.2.1",
-        "semver": "4.3.6"
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
       },
       "dependencies": {
         "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         },
         "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
@@ -11442,7 +10789,7 @@
       "integrity": "sha1-rl/4wfk+2HrcZTCpdWWxJvWFRUs=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
         "once": "1.2.0"
       },
       "dependencies": {
@@ -11473,14 +10820,12 @@
       "dev": true
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
       "integrity": "sha1-w2WgimnEQ6zP6zqd6rNePwq6pHY=",
       "dev": true
     },
@@ -11535,85 +10880,76 @@
       }
     },
     "react": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
+      "version": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
       "integrity": "sha1-ot+oUzXX3AK4K0gvCJWC5kzBM1Y=",
       "dev": true,
       "requires": {
-        "envify": "3.4.1"
+        "envify": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz"
       }
     },
     "react-templates": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/react-templates/-/react-templates-0.1.22.tgz",
+      "version": "https://registry.npmjs.org/react-templates/-/react-templates-0.1.22.tgz",
       "integrity": "sha1-zR26QDztK5A6JGa/f1FF2fMWFS0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cheerio": "0.19.0",
-        "escodegen": "1.8.1",
-        "esprima-harmony": "7001.1.0-dev-harmony-fb",
-        "lodash": "3.10.1",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+        "esprima-harmony": "https://registry.npmjs.org/esprima-harmony/-/esprima-harmony-7001.1.0-dev-harmony-fb.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
         "optionator": "0.6.0",
-        "text-table": "0.2.0"
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
       },
       "dependencies": {
         "escodegen": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "source-map": "0.2.0"
           },
           "dependencies": {
             "esprima": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
               "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
               "dev": true
             },
             "optionator": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
               "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
               "dev": true,
               "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
               }
             }
           }
         },
         "esprima-harmony": {
-          "version": "7001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-harmony/-/esprima-harmony-7001.1.0-dev-harmony-fb.tgz",
+          "version": "https://registry.npmjs.org/esprima-harmony/-/esprima-harmony-7001.1.0-dev-harmony-fb.tgz",
           "integrity": "sha1-lwzsF6HbKdcr+OhrntgGXwFY0EM=",
           "dev": true
         },
         "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -11623,11 +10959,11 @@
           "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
+            "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "fast-levenshtein": "1.0.7",
             "levn": "0.2.5",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
+            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "wordwrap": "0.0.3"
           },
           "dependencies": {
@@ -11643,8 +10979,8 @@
               "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
               "dev": true,
               "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
               }
             },
             "wordwrap": {
@@ -11662,69 +10998,62 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "react-tools": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+      "version": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
       "integrity": "sha1-2mrH1Nd3elml6VHPRucv1La0Ciw=",
       "dev": true,
       "requires": {
-        "commoner": "0.10.8",
-        "jstransform": "10.1.0"
+        "commoner": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+        "jstransform": "http://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz"
       },
       "dependencies": {
         "base62": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+          "version": "http://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
           "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ=",
           "dev": true
         },
         "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb",
-          "resolved": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+          "version": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
           "integrity": "sha1-YzrNtA2b1NuKHB1owGqUKVn60rA=",
           "dev": true
         },
         "jstransform": {
-          "version": "10.1.0",
-          "resolved": "http://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+          "version": "http://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
           "integrity": "sha1-tMSb9j8WLBCLA0g5moc3xxOwqDo=",
           "dev": true,
           "requires": {
-            "base62": "0.1.1",
-            "esprima-fb": "13001.1001.0-dev-harmony-fb",
-            "source-map": "0.1.31"
+            "base62": "http://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+            "esprima-fb": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+            "source-map": "http://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
           }
         },
         "source-map": {
-          "version": "0.1.31",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+          "version": "http://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
           "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "reactify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
       "integrity": "sha1-qPEZWWJzwNS/savqDBTCYB6gO7o=",
       "dev": true,
       "requires": {
-        "react-tools": "0.13.3",
-        "through": "2.3.8"
+        "react-tools": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "read": {
@@ -11744,31 +11073,98 @@
         }
       }
     },
+    "read-installed": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+      "dev": true,
+      "requires": {
+        "debuglog": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "read-package-json": "2.0.12",
+        "readdir-scoped-modules": "1.0.2",
+        "semver": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
+        "slide": "1.1.6",
+        "util-extend": "1.0.3"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "read-only-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
       "integrity": "sha1-Xad8eZ7ROI0++IoYRxu1kk+KC6E=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
         "readable-wrap": "1.0.0"
       }
     },
+    "read-package-json": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "json-parse-better-errors": "1.0.1",
+        "normalize-package-data": "2.4.0",
+        "slash": "1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "3.0.4",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
     "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
       },
       "dependencies": {
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -11780,19 +11176,19 @@
       "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       }
     },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+    "readdir-scoped-modules": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
         "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
       },
       "dependencies": {
         "graceful-fs": {
@@ -11800,10 +11196,27 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
+        }
+      }
+    },
+    "readdirp": {
+      "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
@@ -11822,13 +11235,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "string_decoder": {
@@ -11902,30 +11315,27 @@
       }
     },
     "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+      "version": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
       "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
       "dev": true,
       "requires": {
-        "esprima": "1.0.4"
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         }
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
       }
     },
     "registry-url": {
@@ -11944,23 +11354,20 @@
       "dev": true
     },
     "rename-function-calls": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
       "integrity": "sha1-f4M2nAB6MAf2q+MDPM+BaGoQjgE=",
       "dev": true,
       "requires": {
-        "detective": "3.1.0"
+        "detective": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz"
       }
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
@@ -11970,25 +11377,25 @@
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
         "aws4": "1.6.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.5",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
         "extend": "3.0.1",
-        "forever-agent": "0.6.1",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
         "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
         "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
         "qs": "6.3.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.4.3",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
         "uuid": "3.1.0"
       }
     },
@@ -12011,13 +11418,12 @@
       }
     },
     "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
       }
     },
     "resolve": {
@@ -12027,19 +11433,17 @@
       "dev": true
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
       }
     },
     "retry": {
@@ -12049,18 +11453,16 @@
       "dev": true
     },
     "reversepoint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/reversepoint/-/reversepoint-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/reversepoint/-/reversepoint-0.2.1.tgz",
       "integrity": "sha1-0qw/9NZlzw/3Ipa3p47nI39lk/U=",
       "dev": true
     },
     "rfile": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
       "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
       "dev": true,
       "requires": {
-        "callsite": "1.0.0",
+        "callsite": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
         "resolve": "0.3.1"
       },
       "dependencies": {
@@ -12083,8 +11485,7 @@
       }
     },
     "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
@@ -12095,16 +11496,15 @@
       "dev": true,
       "requires": {
         "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "ruglify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
       "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
       "dev": true,
       "requires": {
-        "rfile": "1.0.0",
+        "rfile": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
         "uglify-js": "2.2.5"
       },
       "dependencies": {
@@ -12115,18 +11515,17 @@
           "dev": true,
           "requires": {
             "optimist": "0.3.7",
-            "source-map": "0.1.43"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
           }
         }
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
       }
     },
     "rx": {
@@ -12136,8 +11535,7 @@
       "dev": true
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
@@ -12148,14 +11546,12 @@
       "dev": true
     },
     "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "semver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
       "integrity": "sha1-NWKUqQaQtph3TWLPNdfJH5g+coo=",
       "dev": true
     },
@@ -12177,24 +11573,21 @@
       }
     },
     "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "shallow-copy": {
@@ -12210,7 +11603,7 @@
       "dev": true,
       "requires": {
         "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.8"
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "shell-quote": {
@@ -12220,14 +11613,12 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
     "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
@@ -12237,10 +11628,10 @@
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
+        "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+        "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
       }
     },
     "sinon-chai": {
@@ -12249,28 +11640,58 @@
       "integrity": "sha512-3kbzpr2q8N+M4CWkcym349ifwkXorsbw2YyVpEIvB3AKC/ebrLHXj3DySt8epKGA49zJBSgn1OvWHZ+O+aR0dA==",
       "dev": true
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
       }
     },
     "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
       }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
     },
     "split2": {
       "version": "2.1.1",
@@ -12293,13 +11714,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "string_decoder": {
@@ -12330,8 +11751,7 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -12341,10 +11761,10 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
         "assert-plus": "1.0.0",
         "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
@@ -12365,30 +11785,27 @@
       "integrity": "sha1-zSp/tLXE2EPiCFWf8hZ13EbjGu8="
     },
     "stream-browserify": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
       "integrity": "sha1-lc8bNpdy4nra9GNSJlFSaJxsS+k=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process": "0.5.2"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
       },
       "dependencies": {
         "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "version": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
           "dev": true
         }
       }
     },
     "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
       }
     },
     "stream-combiner2": {
@@ -12397,7 +11814,7 @@
       "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.0.2",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
         "through2": "0.5.1"
       },
       "dependencies": {
@@ -12407,9 +11824,9 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "string_decoder": "0.10.31"
           }
         },
@@ -12438,34 +11855,30 @@
       }
     },
     "stream-http": {
-      "version": "1.7.1",
-      "resolved": "http://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz",
+      "version": "http://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz",
       "integrity": "sha1-09Km4Uw2o4udr7GZrue7xXBRmXg=",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "1.0.0",
-        "foreach": "2.0.5",
-        "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "object-keys": "1.0.11",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz",
+        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "foreach": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+          "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
           "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
           "dev": true
         },
         "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
           "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
@@ -12477,10 +11890,10 @@
       "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
       "dev": true,
       "requires": {
-        "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "readable-stream": "1.1.14",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
         "readable-wrap": "1.0.0",
         "through2": "1.1.1"
       },
@@ -12491,7 +11904,7 @@
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "xtend": "4.0.1"
           }
         },
@@ -12530,37 +11943,32 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
     },
     "string_decoder": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
       "integrity": "sha1-9UctCo0WUOyCN1LSTm/WJ7Ob8UE=",
       "dev": true
     },
     "stringify-object": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz",
+      "version": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz",
       "integrity": "sha1-RjNI84/c1P7BwBEITCSlmsZTwe4=",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -12568,8 +11976,7 @@
       }
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
@@ -12580,75 +11987,67 @@
       "dev": true
     },
     "subarg": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
       "integrity": "sha1-PVawfaz7xFu7Y/dnK0O2PkY2jjo=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10"
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
       }
     },
     "sudo-block": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.2.1.tgz",
       "integrity": "sha1-s5SCB0G2bA/gb5ezNPBnQDaDe6U=",
       "dev": true,
       "requires": {
-        "chalk": "0.1.1"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.1.2.tgz",
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.1.2.tgz",
           "integrity": "sha1-W6snwuC76UTuQgV88jre6XCrx8Y=",
           "dev": true
         },
         "chalk": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz",
+          "version": "https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz",
           "integrity": "sha1-/m2QriwnBCRyDIftktNkkLfTbqA=",
           "dev": true,
           "requires": {
-            "ansi-styles": "0.1.2",
-            "has-color": "0.1.7"
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.1.2.tgz",
+            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
           }
         }
       }
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "syntax-error": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "integrity": "sha1-tFSXBtOGzBwdx8JCPxhXm2yt5xA=",
       "dev": true,
       "requires": {
-        "acorn": "2.7.0"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
       },
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
           "dev": true
         }
       }
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
         "string-width": "2.1.0"
       },
       "dependencies": {
@@ -12659,8 +12058,7 @@
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -12676,7 +12074,7 @@
           "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "strip-ansi": "4.0.0"
           }
         },
@@ -12699,7 +12097,7 @@
       "requires": {
         "deep-equal": "0.0.0",
         "defined": "0.0.0",
-        "jsonify": "0.0.0"
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
       },
       "dependencies": {
         "deep-equal": {
@@ -12716,9 +12114,9 @@
       "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
         "fstream": "0.1.31",
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "tar-fs": {
@@ -12756,8 +12154,8 @@
       "dev": true,
       "requires": {
         "bl": "0.9.5",
-        "end-of-stream": "1.0.0",
-        "readable-stream": "1.1.14",
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -12770,8 +12168,7 @@
       }
     },
     "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -12782,73 +12179,65 @@
       "dev": true
     },
     "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+      "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "time-grunt": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "date-time": "1.1.0",
-        "figures": "1.7.0",
-        "hooker": "0.2.3",
-        "number-is-nan": "1.0.1",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "date-time": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "hooker": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
         "pretty-ms": "2.1.0",
-        "text-table": "0.2.0"
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
       }
     },
     "time-zone": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz",
       "integrity": "sha1-Sncotqwo2w4Aj1FAQ/1VW9VXO0Y=",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
       "integrity": "sha1-/7pwycEu7ZFv1nMY5imsbzIpVVE=",
       "dev": true,
       "requires": {
-        "process": "0.5.2"
+        "process": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
       },
       "dependencies": {
         "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "version": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
           "dev": true
         }
@@ -12888,7 +12277,7 @@
       "integrity": "sha1-gGGFR/Y/aX0Fy0DEwsSwg1Ia77Y=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
         "faye-websocket": "0.4.4",
         "noptify": "0.0.3",
         "qs": "0.5.6"
@@ -12903,17 +12292,15 @@
       }
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
       }
     },
     "to-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
@@ -12932,35 +12319,32 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
           }
         }
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
       }
     },
     "transformify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
       "integrity": "sha1-mk9CoVRDPdcnuAV1Qoo8nlSJ6/E=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       }
     },
     "traverse": {
@@ -12970,20 +12354,17 @@
       "dev": true
     },
     "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
@@ -12995,23 +12376,20 @@
       "optional": true
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
       }
     },
     "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
       "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
       "dev": true
     },
     "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -13026,14 +12404,13 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
       "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
       "requires": {
-        "async": "0.2.10",
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
         "optimist": "0.3.7",
-        "source-map": "0.1.43"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
     },
@@ -13044,14 +12421,13 @@
       "dev": true
     },
     "umd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz",
       "integrity": "sha1-dJaDsNUUcorg4bYZX1d0r8CtT48=",
       "dev": true,
       "requires": {
-        "rfile": "1.0.0",
-        "ruglify": "1.0.0",
-        "through": "2.3.8",
+        "rfile": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+        "ruglify": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
         "uglify-js": "2.4.24"
       },
       "dependencies": {
@@ -13061,7 +12437,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "uglify-js": {
@@ -13070,23 +12446,21 @@
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
+            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
             "source-map": "0.1.34",
-            "uglify-to-browserify": "1.0.2",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "yargs": "3.5.4"
           }
         }
       }
     },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "version": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
@@ -13096,32 +12470,29 @@
       "integrity": "sha1-+bUOnFsKF43hc4tN5VU369AKuPc="
     },
     "update-notifier": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
+      "version": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
       "integrity": "sha1-IVy+EFM2nw1KRPhLUeuny4BIRpU=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
         "configstore": "0.3.2",
         "request": "2.79.0",
         "semver": "2.3.2"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "version": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
           }
         },
         "semver": {
@@ -13131,58 +12502,57 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
       }
     },
     "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "version": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
       }
     },
     "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         }
       }
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "uuid": {
@@ -13191,22 +12561,39 @@
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+      "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+      "dev": true,
+      "requires": {
+        "builtins": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+      }
+    },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
       "dev": true,
       "requires": {
-        "extsprintf": "1.0.2"
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
-        "indexof": "0.0.1"
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
       }
     },
     "watchify": {
@@ -13215,7 +12602,7 @@
       "integrity": "sha1-8HX9LoqGrN6Eztum5cKgvt1SPZ4=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
         "browserify": "14.4.0",
         "chokidar": "1.7.0",
         "defined": "1.0.0",
@@ -13231,7 +12618,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
           }
         },
         "assert": {
@@ -13240,7 +12627,7 @@
           "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
           "dev": true,
           "requires": {
-            "util": "0.10.3"
+            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
           }
         },
         "base64-js": {
@@ -13289,7 +12676,7 @@
             "assert": "1.4.1",
             "browser-pack": "6.0.2",
             "browser-resolve": "1.11.2",
-            "browserify-zlib": "0.1.4",
+            "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
             "buffer": "5.0.6",
             "cached-path-relative": "1.0.1",
             "concat-stream": "1.5.2",
@@ -13298,23 +12685,23 @@
             "crypto-browserify": "3.11.1",
             "defined": "1.0.0",
             "deps-sort": "2.0.0",
-            "domain-browser": "1.1.7",
+            "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
             "duplexer2": "0.1.4",
             "events": "1.1.1",
             "glob": "7.1.2",
-            "has": "1.0.1",
-            "htmlescape": "1.1.1",
+            "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "htmlescape": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
             "https-browserify": "1.0.0",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "insert-module-globals": "7.0.1",
             "labeled-stream-splicer": "2.0.0",
             "module-deps": "4.1.1",
-            "os-browserify": "0.1.2",
+            "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
             "parents": "1.0.1",
-            "path-browserify": "0.0.0",
+            "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
             "process": "0.11.10",
             "punycode": "1.4.1",
-            "querystring-es3": "0.2.0",
+            "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
             "read-only-stream": "2.0.0",
             "readable-stream": "2.3.3",
             "resolve": "1.3.3",
@@ -13324,13 +12711,13 @@
             "stream-http": "2.7.2",
             "string_decoder": "1.0.3",
             "subarg": "1.0.0",
-            "syntax-error": "1.1.6",
+            "syntax-error": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
             "through2": "2.0.3",
-            "timers-browserify": "1.0.3",
-            "tty-browserify": "0.0.0",
+            "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+            "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "url": "0.11.0",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4",
+            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
             "xtend": "4.0.1"
           }
         },
@@ -13341,7 +12728,7 @@
           "dev": true,
           "requires": {
             "base64-js": "1.2.1",
-            "ieee754": "1.1.8"
+            "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
           }
         },
         "builtin-status-codes": {
@@ -13368,9 +12755,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
           },
           "dependencies": {
             "readable-stream": {
@@ -13379,12 +12766,12 @@
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                 "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                 "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
               }
             },
             "string_decoder": {
@@ -13428,7 +12815,7 @@
             "create-hash": "1.1.3",
             "create-hmac": "1.1.6",
             "diffie-hellman": "5.0.2",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "pbkdf2": "3.0.12",
             "public-encrypt": "4.0.0",
             "randombytes": "2.0.5"
@@ -13483,12 +12870,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "https-browserify": {
@@ -13540,7 +12927,7 @@
           "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "0.0.1",
             "stream-splicer": "2.0.0"
           },
@@ -13590,7 +12977,7 @@
             "defined": "1.0.0",
             "detective": "4.5.0",
             "duplexer2": "0.1.4",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "parents": "1.0.1",
             "readable-stream": "2.3.3",
             "resolve": "1.3.3",
@@ -13642,13 +13029,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "resolve": {
@@ -13669,7 +13056,7 @@
             "array-filter": "0.0.1",
             "array-map": "0.0.0",
             "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         },
         "source-map": {
@@ -13684,7 +13071,7 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "readable-stream": "2.3.3"
           }
         },
@@ -13705,9 +13092,9 @@
           "dev": true,
           "requires": {
             "builtin-status-codes": "3.0.0",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "readable-stream": "2.3.3",
-            "to-arraybuffer": "1.0.1",
+            "to-arraybuffer": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "xtend": "4.0.1"
           }
         },
@@ -13717,7 +13104,7 @@
           "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "readable-stream": "2.3.3"
           }
         },
@@ -13762,7 +13149,7 @@
           "dev": true,
           "requires": {
             "punycode": "1.3.2",
-            "querystring": "0.2.0"
+            "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
           },
           "dependencies": {
             "punycode": {
@@ -13794,36 +13181,31 @@
       "dev": true
     },
     "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
       "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
       "dev": true,
       "requires": {
-        "semver": "5.3.0"
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
       },
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -13834,28 +13216,44 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
           }
+        }
+      }
+    },
+    "write-file-atomic": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+      "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "slide": "1.1.6"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
         }
       }
     },
@@ -13865,28 +13263,25 @@
       "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
       }
     },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
     "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dev": true,
       "requires": {
-        "object-keys": "0.4.0"
+        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
       }
     },
     "yargs": {
@@ -13895,9 +13290,9 @@
       "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0",
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
         "wordwrap": "0.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "keywords": [],
   "dependencies": {
     "amortize": "0.2.2",
-    "cfgov-sheer-templates": "^2.1.8",
+    "cfgov-sheer-templates": "^2.1.9",
     "date-format": "0.0.2",
     "debounce": "0.0.3",
     "foreach": "2.0.4",


### PR DESCRIPTION
- Removes npm-shrinkwrap in favor of package-lock.
- Updates to latest cfgov-sheer-templates.