### PR TITLE
Update Informa text on rate-checker page

### DIFF
--- a/src/explore-rates/index.html
+++ b/src/explore-rates/index.html
@@ -24,7 +24,7 @@
         <section class="page-intro content-l">
           <div class="content-l_col content-l_col-2-3">
             <h2 class="page-title">Explore interest rates<sup class="beta">BETA</sup></h2>
-            <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  Check back often -- the rates in the tool are updated daily.</p>
+            <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  Check back often -- the rates in the tool are updated every Wednesday and Friday.</p>
             <div class="page-intro_cols">
               <p class="page-intro_col-left u-mb30">
                 Keep in mind that the interest rate is important, but not the only cost of a mortgage.  Fees, <a href="http://www.consumerfinance.gov/askcfpb/136/what-are-discount-points-and-lender-credits-and-how-do-they-work.html">points</a>, <a href="http://www.consumerfinance.gov/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html">mortgage insurance</a>, and <a href="http://www.consumerfinance.gov/askcfpb/1845/what-fees-or-charges-are-paid-closing-and-who-pays-them.html">closing costs</a> all add up.  Compare <a href="http://www.consumerfinance.gov/askcfpb/1995/what-is-a-loan-estimate.html">Loan Estimates</a> to get the best deal.
@@ -449,7 +449,7 @@
               <div class="content-l_col content-l_col-1-3">
                 <h3 class="subhead">About this tool</h3>
 
-                <p>Our data is provided by real lenders and is updated every business day in the evening. The lenders in our data include a mix of large banks, regional banks, and credit unions.</p>
+                <p>The lenders in our data include a mix of large banks, regional banks, and credit unions. The data is updated semiweekly every Wednesday and Friday at 7 a.m. In the event of a holiday, data will be refreshed on the next available business day.</p>
 
                 <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="http://www.informars.com" target="_blank">www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
               </div>


### PR DESCRIPTION
Update rate-checker text to reflect changes to Informa data load schedule. (Per GHE30)

## Changes

- /explore-rates text


## Screenshots
<img width="698" alt="screen shot 2018-03-26 at 10 16 52 am" src="https://user-images.githubusercontent.com/778171/37921786-974451ce-30df-11e8-8824-0250be3d9324.png">

<img width="1186" alt="screen shot 2018-03-26 at 10 16 43 am" src="https://user-images.githubusercontent.com/778171/37921783-957c17dc-30df-11e8-81eb-c8063de80783.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

